### PR TITLE
feature: Add Japanese translation YAML files

### DIFF
--- a/ja/backuprestore.yaml
+++ b/ja/backuprestore.yaml
@@ -1,0 +1,46 @@
+Auto Backup on Restore: 復元時に自動バックアップ
+Available Backups: 利用可能なバックアップ
+Backup Files: バックアップファイル
+Backup Now: 今すぐバックアップ
+Backup and Restore: バックアップと復元
+Backup created successfully: バックアップが正常に作成されました
+Backup deleted successfully: バックアップが正常に削除されました
+Backup on Restore: 復元時のバックアップ
+Browse: 参照
+Create Backup: バックアップを作成
+Create a backup of your data?: データのバックアップを作成しますか？
+Created: 作成日
+Creating backup...: バックアップを作成中...
+Delete: 削除
+Delete this backup? This action cannot be undone.: このバックアップを削除しますか？この操作は元に戻せません。
+Failed to create backup: バックアップの作成に失敗しました
+Failed to delete backup: バックアップの削除に失敗しました
+Failed to load backup list: バックアップリストの読み込みに失敗しました
+Failed to open backup folder: バックアップフォルダーのオープンに失敗しました
+Failed to restore backup: バックアップの復元に失敗しました
+Failed to select backup file: バックアップファイルの選択に失敗しました
+Include images in backup: バックアップに画像を含める
+Invalid backup file: 無効なバックアップファイル
+Loading backups...: バックアップを読み込み中...
+Move to another location?: 別の場所に移動しますか？
+No backups found: バックアップが見つかりません
+Restore: 復元
+Restore Data: データを復元
+Restore completed. The application will restart.: 復元が完了しました。アプリケーションが再起動します。
+Restore from "{{filename}}"? This will replace all current data.: "{{filename}}"から復元しますか？現在のすべてのデータが置き換えられます。
+Restore from File...: ファイルから復元...
+Restore from {{filename}}? This will replace all current data.: {{filename}}から復元しますか？現在のすべてのデータが置き換えられます。
+Restored from {{filename}}: {{filename}}から復元されました
+Restoring a backup will automatically restart the application.: バックアップの復元後、アプリケーションは自動的に再起動します。
+Restoring backup...: バックアップを復元中...
+Restoring...: 復元中...
+Select backup file: バックアップファイルを選択
+Size: サイズ
+The selected file is not a valid PasteBar backup: 選択したファイルは有効なPasteBarバックアップではありません
+This action cannot be undone. All current data will be replaced with the backup data.: この操作は元に戻せません。現在のすべてのデータがバックアップデータで置き換えられます。
+This will create a backup file containing your database: これによりデータベースを含むバックアップファイルが作成されます
+This will replace all current data. Are you sure?: すべての現在のデータが置き換えられます。本当によろしいですか？
+Total backup space {{size}}: バックアップ合計容量: {{size}}
+and images: および画像
+selected file: 選択したファイル
+will be permanently deleted.: 完全に削除されます。

--- a/ja/calendar.yaml
+++ b/ja/calendar.yaml
@@ -1,0 +1,22 @@
+Day: 日
+Days: 日
+Days2: 日
+Days3: 日
+Month: 月
+Months: ヶ月
+Months2: ヶ月
+Older then: より古い
+Hour: 時間
+Hours: 時間
+Week: 週
+Weeks: 週間
+Week2: 週
+Year: 年
+Years: 年
+Years2: 年
+and older: 以上前
+last: 最後
+last2: 最後
+last3: 最後
+older then: より古い
+recent: 最近

--- a/ja/collections.yaml
+++ b/ja/collections.yaml
@@ -1,0 +1,26 @@
+Add Collection: コレクションを追加
+Add a description for your collection: コレクションの説明を追加
+Add default menu, tab and board: デフォルトのメニュー、タブ、ボードを追加
+Are you sure you want to delete this collection?: このコレクションを削除してもよろしいですか？
+Choose which collections require PIN entry for access.: アクセスにPINが必要なコレクションを選択してください。
+Collection Options: コレクションのオプション
+Collection Title: コレクションタイトル
+Collections: コレクション
+Current Collection: 現在のコレクション
+Delete Collection: コレクションを削除
+Delete all menu items within this collection: このコレクション内のすべてのメニュー項目を削除
+? Deleting the collection will remove it permanently. You can also choose to delete all menu and clips items within the collection by checking the box below.
+: コレクションを削除すると完全に削除されます。下のボックスにチェックを入れると、コレクション内のすべてのメニューとクリップ項目も削除できます。
+Description: 説明
+Display full name of selected collection on the navigation bar: 選択したコレクションのフルネームをナビゲーションバーに表示
+Enter collection title: コレクションタイトルを入力
+Manage Collections: コレクションを管理
+Pin Protected Collections: PIN保護コレクション
+Protect Collections with PIN: PINでコレクションを保護
+Protected Collection: 保護されたコレクション
+Select Collections: コレクションを選択
+Select protected collections: 保護されたコレクションを選択
+Show collection name on the navbar: ナビバーにコレクション名を表示
+Switch collections: コレクションを切り替え
+You can add the selected text to your clips or menu. Please select the option below.: 選択したテキストをクリップまたはメニューに追加できます。下のオプションを選択してください。
+You need to select a different collection before deleting the current one.: 現在のコレクションを削除する前に、別のコレクションを選択する必要があります。

--- a/ja/common.yaml
+++ b/ja/common.yaml
@@ -1,0 +1,359 @@
+' No': いいえ
+' This permission ensures PasteBar can access the clipboard and perform copy and paste operations across applications.': この権限によりPasteBarはクリップボードへアクセスし、アプリ間でコピー＆ペースト操作が可能になります。
+About PasteBar: PasteBarについて
+Action Menu: アクションメニュー
+? Add <b>{{Clipboard}}</b> field to template. This allows you to copy text to the clipboard, and it will be inserted into the template
+: テンプレートに<b>{{Clipboard}}</b>フィールドを追加します。これによりテキストをクリップボードにコピーし、テンプレートに挿入できます。
+Add Clip: クリップを追加
+Add First Option: 最初のオプションを追加
+Add Link Card: リンクカードを追加
+Add Menu: メニューを追加
+Add Option: オプションを追加
+Add PasteBar to Accessibility: PasteBarをアクセシビリティに追加
+Add To Player: プレイヤーに追加
+Add to: 追加先
+Add to Clips: クリップに追加
+Add to Clips or Menu: クリップまたはメニューに追加
+Add to Menu: メニューに追加
+Add to clip or menu: クリップまたはメニューに追加
+Add to template fields: テンプレートフィールドに追加
+Added: 追加済み
+Adding this file to the player is not recommended unless you trust the source.: このファイルをプレイヤーに追加するのは信頼できるソースの場合のみ推奨されます。
+Allow PasteBar to Copy and Paste from Clipboard: PasteBarにクリップボードからのコピー＆ペーストを許可
+Are you sure you want to delete?: 本当に削除しますか？
+Are you sure?: よろしいですか？
+Attach History Window: 履歴ウィンドウを添付
+Back: 戻る
+Build on {{buildDate}}: ビルド日: {{buildDate}}
+Cancel: キャンセル
+Cancel Reset: リセットをキャンセル
+Check: チェック
+Check / Done: チェック / 完了
+Check and Close: チェックして閉じる
+Check and Done: チェックして完了
+Clear History: 履歴をクリア
+Clear Tracks: トラックをクリア
+Clear found results and filters: 検索結果とフィルターをクリア
+Click to Confirm: クリックして確認
+Clip: クリップ
+Clip Boards: クリップボード
+Clipboard: クリップボード
+Clipboard History: クリップボード履歴
+Clipboard History Only: クリップボード履歴のみ
+Clipboard History Settings: クリップボード履歴設定
+Close: 閉じる
+Close Edit: 編集を閉じる
+Close Expand Edit: 拡張編集を閉じる
+Close Find: 検索を閉じる
+Close History Window: 履歴ウィンドウを閉じる
+Close modal and continue in browser: モーダルを閉じてブラウザで続行
+Confirm: 確認
+Confirm  action: 操作を確認
+Confirm Delete: 削除を確認
+Confirm Email: メールアドレスを確認
+Confirm Passcode: パスコードを確認
+Confirm Password: パスワードを確認
+Confirm Remove: 削除を確認
+Confirm Your Passcode: パスコードを確認
+Confirm Passcode Reset: パスコードリセットを確認
+Confirm Password Reset: パスワードリセットを確認
+Confirm Add To Protected Collections: 保護コレクションへの追加を確認
+Confirm Disable PIN Protection: PIN保護の無効化を確認
+Confirm Remove From Protected Collections: 保護コレクションからの削除を確認
+Confirm Enable PIN Protection: PIN保護の有効化を確認
+Contact Form: お問い合わせフォーム
+Copied: コピーしました
+Copy: コピー
+Copy & Paste: コピー＆ペースト
+Copy and Paste: コピーとペースト
+'Copy of ': 'のコピー '
+Copy to Clipboard: クリップボードにコピー
+Create: 作成
+Created: 作成済み
+Delay Next: 次を遅延
+Delete: 削除
+Deselect All: すべて選択解除
+Deselect pinned: ピン留め解除
+Digits Only Passcode: 数字のみのパスコード
+Disabled: 無効
+Done: 完了
+Done Adding: 追加完了
+Done Edit: 編集完了
+Done Reorder: 並べ替え完了
+Download mp3: mp3をダウンロード
+Drag: ドラッグ
+Drag to Move: 移動のためにドラッグ
+Drop To Add: ドロップして追加
+Drop Zone: ドロップゾーン
+Edit: 編集
+Edit Label: ラベルを編集
+'Email: {{email}}': 'メール: {{email}}'
+Emoji: 絵文字
+Empty: 空
+Empty Select: 空の選択
+Enable / Disable: 有効/無効
+Enable PasteBar in Accessibility Settings: アクセシビリティ設定でPasteBarを有効化
+Enabled: 有効
+Enter Current Passcode: 現在のパスコードを入力
+Enter Digits Only Passcode: 数字のみのパスコードを入力
+Enter Email: メールアドレスを入力
+Enter PIN to Access Protected Collection: 保護コレクションにアクセスするためPINを入力
+Enter Passcode: パスコードを入力
+Enter Password: パスワードを入力
+Enter Recovery Password: 復旧用パスワードを入力
+Enter passcode or password to unlock: パスコードまたはパスワードでロック解除
+Error: エラー
+Errors:
+  Error loading link: リンクの読み込みエラー
+  Cant save to file: ファイルへの保存に失敗
+  Something went wrong! {{err}} Please try again.: 問題が発生しました！{{err}} もう一度お試しください。
+Expand Edit: 編集を拡張
+Expires on {{proExpiresOn}}: 有効期限: {{proExpiresOn}}
+? Field <b>{{Clipboard}}</b> has been found in the template. This allows you to copy text to the clipboard, and it will be inserted into the template
+: テンプレートに<b>{{Clipboard}}</b>フィールドが見つかりました。これによりテキストをクリップボードにコピーし、テンプレートに挿入できます。
+Field is not found in the template: テンプレートにフィールドが見つかりません
+Find Clip: クリップを検索
+Find History: 履歴を検索
+Found in template but missing from fields definition: テンプレートに存在しますがフィールド定義にありません
+Got it: わかりました
+Hide Muli Select: 複数選択を隠す
+Hide Pinned Board: ピン留めボードを隠す
+History: 履歴
+Image: 画像
+Image Scale {{ImageScale}}x: 画像スケール{{ImageScale}}倍
+Image size: 画像サイズ
+Image size in pixels: ピクセル単位の画像サイズ
+In View: 表示中
+In View Edit: 編集表示中
+Inactive: 非アクティブ
+Large View: 大きく表示
+Large View Edit: 大きく編集
+Later: 後で
+Light: ライト
+Lines Wrap: 行の折り返し
+Make Active: アクティブにする
+Make Disabled: 無効にする
+Make Enabled: 有効にする
+Make Inactive: 非アクティブにする
+Manage: 管理
+Maximum height: 最大高さ
+Maximum length: 最大長
+Maximum width: 最大幅
+Menu: メニュー
+Minimum length: 最小長
+Move Down: 下へ移動
+Move Up: 上へ移動
+Multi Select: 複数選択
+'Name: {{name}}': '名前: {{name}}'
+Next Delay: 次の遅延
+Next Track: 次のトラック
+No: いいえ
+No Key Press: キー入力なし
+No Wrap: 折り返しなし
+Not Now: 今はしない
+Not found in the template: テンプレートに見つかりません
+Nothing found: 何も見つかりません
+Number of lines: 行数
+Ok, but later: OK、でも後で
+Open: 開く
+Open Accessibility: アクセシビリティを開く
+Open History Window: 履歴ウィンドウを開く
+Open Window: ウィンドウを開く
+Open contact form in browser: ブラウザでお問い合わせフォームを開く
+Open payment in browser: ブラウザで支払いを開く
+Options: オプション
+Password: パスワード
+Paste Delay: ペースト遅延
+Paste Menu: ペーストメニュー
+Paste in {{pastingCountDown}}...: {{pastingCountDown}}秒後にペースト...
+PasteBar: PasteBar
+PasteBar Application Error: PasteBarアプリケーションエラー
+PasteBar History: PasteBar履歴
+PasteBar application now can access the clipboard and perform copy and paste operations across applications.: PasteBarアプリケーションはクリップボードにアクセスし、アプリ間でコピー＆ペースト操作が可能になりました。
+PasteBar was successfuly added to Accessibility settings: PasteBarがアクセシビリティ設定に正常に追加されました
+Pasted: ペーストされました
+Path: パス
+Pause: 一時停止
+Pause Playing: 再生を一時停止
+? 'Permission Check Failed: PasteBar has not been successfully added to Accessibility settings. Please grant the required permissions and click Done again.'
+: 権限チェックに失敗しました: PasteBarがアクセシビリティ設定に正常に追加されていません。必要な権限を付与し、再度「完了」をクリックしてください。
+Pin Selected: 選択したものをピン留め
+Pinned: ピン留め
+Play: 再生
+Please add PasteBar to the list of apps in: PasteBarをアプリ一覧に追加してください
+Please confirm your action!: 操作を確認してください！
+Press: 押す
+Press ESC key to close: ESCキーで閉じる
+Previous Track: 前のトラック
+Pro: Pro
+Quit: 終了
+Rebuild Menu: メニューを再構築
+Recent History: 最近の履歴
+Recovery Password: 復旧用パスワード
+Remove: 削除
+Remove Link Card: リンクカードを削除
+Remove Selected Star: 選択したスターを削除
+Remove all fields from template: テンプレートからすべてのフィールドを削除
+Remove all tracks: すべてのトラックを削除
+Remove current track: 現在のトラックを削除
+Remove from Player: プレイヤーから削除
+Remove from template: テンプレートから削除
+Rename: 名前を変更
+Renew: 更新
+Reorder pinned: ピン留めを並べ替え
+Repeat 1: 1回リピート
+Repeat all: 全てリピート
+Repeat off: リピートオフ
+Report and Try Again: 報告して再試行
+Reset: リセット
+Reset Passcode: パスコードをリセット
+Reset Password: パスワードをリセット
+Reset with Passcode: パスコードでリセット
+Restart: 再起動
+Reverse Order: 逆順
+Run and Copy Response: 実行してレスポンスをコピー
+Run and Paste Response: 実行してレスポンスをペースト
+Running: 実行中
+Save: 保存
+Save It!: 保存する！
+Saved: 保存済み
+Scroll to Top: 一番上へスクロール
+Second: 秒
+Seconds: 秒
+'Security Alert: MP3 Verification Failed': 'セキュリティ警告: MP3検証失敗'
+Select: 選択
+Select Default Option: デフォルトオプションを選択
+Select Language: 言語を選択
+Select default: デフォルトを選択
+Select is empty: 選択が空です
+Select option: オプションを選択
+Select pinned: ピン留めを選択
+Separate History Window: 履歴ウィンドウを分離
+Sequence Copy: シーケンスコピー
+Sequence Copy Paste: シーケンスコピー＆ペースト
+Sequence Delay Next: シーケンス次遅延
+Sequence Next Delay: シーケンス次遅延
+Sequence Paste: シーケンスペースト
+Sequence Reverse Order: シーケンス逆順
+Set: 設定
+Set Password: パスワードを設定
+Show Large View: 大きく表示
+Show all: すべて表示
+Size: サイズ
+Source: ソース
+Star: スター
+Star Selected: スター選択
+Stay here: ここにとどまる
+Stay in touch: 連絡を取り続ける
+Success!: 成功！
+Swap Panels Layout: パネルレイアウトを入れ替え
+System Settings -> Privacy & Security -> Accessibility: システム設定→プライバシーとセキュリティ→アクセシビリティ
+Thank you for reporting the error.: エラーのご報告ありがとうございます。
+Thank you for using Pro: Proをご利用いただきありがとうございます
+Thank you!: ありがとうございます！
+This permission ensures PasteBar can access the clipboard and perform copy and paste operations across applications.: この権限によりPasteBarはクリップボードへアクセスし、アプリ間でコピー＆ペースト操作が可能になります。
+Too long: 長すぎます
+Too short: 短すぎます
+Toolbar:
+  Blank Text Formatting: 空白テキストの書式設定
+  Bold Formatting: 太字書式
+  Bold Text Formatting: 太字テキスト書式
+  Copy and Paste Formatting: コピー＆ペースト書式
+  Header Formatting: ヘッダー書式
+  Hightlight Text Formatting: ハイライトテキスト書式
+  Italic Formatting: 斜体書式
+  Masked Text Formatting: マスクテキスト書式
+  Remove Text Formatting: 書式を削除
+Trust and Play: 信頼して再生
+Type:
+  App: アプリ
+  Auto Fill: 自動入力
+  AutoFill: 自動入力
+  Clip: クリップ
+  Code: コード
+  Code Snippet: コードスニペット
+  Command: コマンド
+  Email: メール
+  Emoji: 絵文字
+  Empty: 空
+  Error: エラー
+  File: ファイル
+  File, Path or App: ファイル・パス・アプリ
+  Form Auto Fill: フォーム自動入力
+  Image: 画像
+  Label: ラベル
+  Link: リンク
+  Link or Email: リンクまたはメール
+  Menu: メニュー
+  Mp3: mp3
+  Path: パス
+  Plain Text: プレーンテキスト
+  Request: リクエスト
+  Run Auto Fill: 自動入力を実行
+  Scraper: スクレイパー
+  Secret: シークレット
+  Trim: 空白をトリム
+  Shell Command: シェルコマンド
+  Submenu: サブメニュー
+  Template: テンプレート
+  Template Fill: テンプレート入力
+  Text: テキスト
+  Video: ビデオ
+  Web Request (HTTP): Webリクエスト(HTTP)
+  Web Scraper / Parser: Webスクレイパー/パーサー
+TypeMenu:
+  Clip Type: クリップタイプ
+  Code Snippet: コードスニペット
+  File, Path or App: ファイル・パス・アプリ
+  Form Auto Fill: フォーム自動入力
+  Image: 画像
+  Link or Email: リンクまたはメール
+  Link or File, Path or App: リンクまたはファイル・パス・アプリ
+  Plain Text: プレーンテキスト
+  Run, Execute: 実行
+  Select Language: 言語を選択
+  Shell Command: シェルコマンド
+  Template: テンプレート
+  Template Fill: テンプレート入力
+  Text Template: テキストテンプレート
+  Web Request (HTTP): Webリクエスト(HTTP)
+  Web Scraper / Parser: Webスクレイパー/パーサー
+UnPin All: すべてのピンを解除
+UnPin Selected: 選択したピンを解除
+Unlock Application Screen: アプリ画面のロック解除
+Unlock Pro features: Pro機能をアンロック
+Unlock Screen: 画面ロック解除
+Unlock all features: すべての機能をアンロック
+Unsaved label: 未保存ラベル
+Update Error: 更新エラー
+Update history list: 履歴リストを更新
+Updated: 更新済み
+Upgrade to Pro: Proにアップグレード
+Use Passcode: パスコードを使用
+Use Password: パスワードを使用
+Using <b>{{Clipboard}}</b> field, allows you to copy text to the clipboard, and it will be inserted into the template: <b>{{Clipboard}}</b>フィールドを使うと、テキストをクリップボードにコピーしテンプレートに挿入できます
+Verify: 検証
+Verify Current Password: 現在のパスワードを検証
+Verify Recovery Password: 復旧用パスワードを検証
+Version: バージョン
+View: 表示
+View Edit: 編集表示
+Views:
+  Paste Menu: ペーストメニュー
+We apologize but you found a bug. Please report this issue to us and try again: バグを発見いただき申し訳ありません。この問題を報告し再度お試しください
+? We couldn't confirm this file's safety. Failed ID3 tag verification and integrity check. MP3 files can potentially contain malware. Please be cautious.
+: このファイルの安全性を確認できませんでした。ID3タグ検証と整合性チェックに失敗しました。MP3ファイルにはマルウェアが含まれる可能性があります。ご注意ください。
+Yes: はい
+Yes, activate: はい、有効化
+chars: 文字
+contact us.: お問い合わせください。
+found: 見つかりました
+if this error persists, try to restart the application or: このエラーが続く場合はアプリを再起動するか
+lines: 行
+menu items in: メニュー項目
+minutes: 分
+only: のみ
+second: 秒
+seconds: 秒
+show less: 表示を減らす
+www.site: www.pastebar.app

--- a/ja/common2.yaml
+++ b/ja/common2.yaml
@@ -1,0 +1,4 @@
+Please select your preferred language: ご希望の言語を選択してください
+Start using PasteBar: PasteBarの利用を開始
+Submenus will move up one level after delete: サブメニューは削除後1つ上の階層に移動します
+Welcome to PasteBar: PasteBarへようこそ

--- a/ja/contextMenus.yaml
+++ b/ja/contextMenus.yaml
@@ -1,0 +1,109 @@
+Activate: 有効化
+Add Board: ボードを追加
+Add Clip: クリップを追加
+Add First Tab: 最初のタブを追加
+Add Item: アイテムを追加
+Add Link Card: リンクカードを追加
+Add New: 新規追加
+Add New After: 後に新規追加
+Add New Item: 新しいアイテムを追加
+Add Tab: タブを追加
+Add to: 追加先
+Add to Menu: メニューに追加
+AddTo:
+  Add to Exclude and Delete: 除外・削除に追加
+  Add to Filter by Source: ソースでフィルターに追加
+  Add to Ignore: 無視リストに追加
+  Clip on Board: ボード上のクリップ
+  Paste Menu: ペーストメニュー
+After: 後
+After Item: アイテムの後
+Board Icon: ボードアイコン
+Clip Icon: クリップアイコン
+Close: 閉じる
+Close Edit: 編集を閉じる
+Close Rename: 名前変更を閉じる
+Close View: 表示を閉じる
+Collapse View: 表示を折りたたむ
+Copy & Paste: コピー＆ペースト
+Copy To: コピー先
+CopyTo:
+  Board: ボード
+  Tab: タブ
+Custom Icon: カスタムアイコン
+Dashboard: ダッシュボード
+Delete Board: ボードを削除
+Delete Clip: クリップを削除
+Deselect: 選択解除
+Detected Language: 検出言語
+Down: 下
+Duplicate: 複製
+Edit Board: ボードを編集
+Edit Clip: クリップを編集
+Edit Label: ラベルを編集
+Edit Tabs: タブを編集
+Edit Value: 値を編集
+End: 終了
+Expand View: 表示を拡大
+Hide: 非表示
+Hide Details: 詳細を非表示
+Hide Subtitle: サブタイトルを非表示
+Icon Type: アイコンタイプ
+Icon Visibility: アイコンの表示
+Large View: 大きく表示
+Link To Clip: クリップにリンク
+Locate Clip: クリップを探す
+Locate Menu: メニューを探す
+Make Disabled: 無効にする
+Make Enabled: 有効にする
+Make Inactive: 非アクティブにする
+Manage: 管理
+Mask Secret: シークレットをマスク
+Menu: メニュー
+Menu is Not Active: メニューは非アクティブ
+Move Board To: ボードの移動先
+Move To: 移動先
+MoveTo:
+  Board: ボード
+  Tab: タブ
+Note Icon: ノートアイコン
+Note Icon Settings: ノートアイコン設定
+Note Icon Types Book: 本
+Note Icon Types Contact: 連絡先
+Note Icon Types File: ファイル
+Note Icon Types Message: メッセージ
+Note Icon Types Notebook: ノート
+Open: 開く
+Open Link in Browser: ブラウザでリンクを開く
+Organize: 整理
+Organize Layout: レイアウトを整理
+Paste Delay: ペースト遅延
+Paste Menu: ペーストメニュー
+Pin: ピン留め
+Position: 位置
+RESET: リセット
+Remove Link Card: リンクカードを削除
+Remove Star: スターを削除
+Rename: 名前を変更
+Save as File: ファイルとして保存
+Save as Image File: 画像ファイルとして保存
+Save as Mp3: mp3として保存
+Save as Mp3 File: mp3ファイルとして保存
+Save as Text File: テキストファイルとして保存
+Select: 選択
+Select Icon: アイコンを選択
+Separator: セパレーター
+Show: 表示
+Show Large View: 大きく表示
+Show Note Icon: ノートアイコンを表示
+Show Subtitle: サブタイトルを表示
+Star: スター
+Start: 開始
+Submenu: サブメニュー
+UnPin: ピンを外す
+UnPin Clip: クリップのピンを外す
+Unmask Secret: シークレットのマスクを解除
+Up: 上
+Use Global Setting: グローバル設定を使用
+View: 表示
+not a code: コードではありません

--- a/ja/dashboard.yaml
+++ b/ja/dashboard.yaml
@@ -1,0 +1,269 @@
+API Key: APIキー
+Add: 追加
+Add Auth: 認証を追加
+Add Clipboard Value: クリップボード値を追加
+Add Custom: カスタム追加
+Add Custom Field: カスタムフィールドを追加
+Add Delay Time: 遅延時間を追加
+Add First Board: 最初のボードを追加
+Add Form Field: フォームフィールドを追加
+Add Header: ヘッダーを追加
+Add Key Press: キー入力を追加
+Add Key Press After Paste: ペースト後のキー入力を追加
+Add Link Card: リンクカードを追加
+Add Open URL: URLを開くを追加
+Add Output Template: 出力テンプレートを追加
+Add Regex Match Group Filter: 正規表現グループフィルターを追加
+Add Request Header: リクエストヘッダーを追加
+Add Response Filter: レスポンスフィルターを追加
+Add Scraping Rule: スクレイピングルールを追加
+Add Section: セクションを追加
+Add Tab: タブを追加
+Add Template Field: テンプレートフィールドを追加
+Add a Tab: タブを追加
+Add field {{name}} into the template: テンプレートに{{name}}フィールドを追加
+Add image: 画像を追加
+Add note: ノートを追加
+Add to Board: ボードに追加
+Add {{type}}: {{type}}を追加
+All field labels must be unique to ensure they are correctly used within the template.: すべてのフィールドラベルは一意である必要があります。テンプレート内で正しく使用されるためです。
+Are you sure you want to delete <strong>{{boardName}}</strong> board?: <strong>{{boardName}}</strong>ボードを削除してもよろしいですか？
+Are you sure you want to delete <strong>{{tabName}}</strong> tab?: <strong>{{tabName}}</strong>タブを削除してもよろしいですか？
+Are you sure you want to delete?: 削除してもよろしいですか？
+Are you sure you want to remove image from the clip?: クリップから画像を削除してもよろしいですか？
+Auth: 認証
+Auto update is Off: 自動更新はオフ
+Basic Auth: ベーシック認証
+Basic Password: ベーシックパスワード
+Basic Username: ベーシックユーザー名
+Bearer Token: ベアラートークン
+Board Layout Height: ボードレイアウトの高さ
+Board Layout Split: ボードレイアウト分割
+Board Menu: ボードメニュー
+Board is Not Empty: ボードは空ではありません
+Boards: ボード
+Border Width: 枠線の幅
+CSS Selector: CSSセレクター
+Cancel: キャンセル
+Change Layout: レイアウトを変更
+Change color: 色を変更
+Clear: クリア
+Clear All Fields: すべてのフィールドをクリア
+Click To Add: クリックして追加
+Clip Menu: クリップメニュー
+Clip Options: クリップオプション
+Clipboard: クリップボード
+Clips:
+  App: アプリ
+  Clip Menu: クリップメニュー
+  Clips: クリップ
+  Link: リンク
+Close Edit: 編集を閉じる
+Command:
+  error: エラー
+  output: 出力
+Command error: コマンドエラー
+Common Fields: 共通フィールド
+Confirm Clear All Fields: すべてのフィールドをクリアしてもよろしいですか？
+Confirm to remove Auth: 認証を削除してもよろしいですか？
+Confirm to remove filters: フィルターを削除してもよろしいですか？
+Confirm to remove headers: ヘッダーを削除してもよろしいですか？
+Copy Clip: クリップをコピー
+Create Board: ボードを作成
+Create Tab: タブを作成
+Create tab: タブを作成
+Dashboard: ダッシュボード
+Delay: 遅延
+Delete Board: ボードを削除
+Delete Clip: クリップを削除
+Delete Tab: タブを削除
+Delete board: ボードを削除
+Delete field: フィールドを削除
+Delete tab: タブを削除
+Detect Template Fields: テンプレートフィールドを検出
+Detect for Template Fields: テンプレートフィールドを検出
+Disabled field {{name}} has been found in the template: 無効なフィールド{{name}}がテンプレートに見つかりました
+Done Create Clip: クリップ作成完了
+Done Edit: 編集完了
+Done Edit Tabs: タブ編集完了
+Done Organize: 整理完了
+Drag & Drop Path: ドラッグ＆ドロップパス
+Drop To Add: ドロップして追加
+Drop image file here, or use a separate window for drag and drop.: ここに画像ファイルをドロップ、または別ウィンドウでドラッグ＆ドロップしてください。
+Drop to Pin: ドロップしてピン留め
+Edit Note: ノートを編集
+Edit Template: テンプレートを編集
+Edit subtitle: サブタイトルを編集
+Edit tab name: タブ名を編集
+Enable / Disable: 有効/無効
+Enable / Disable URL Open: URLオープンの有効/無効
+Enter Label: ラベルを入力
+Enter URL: URLを入力
+Enter board subtitle or description: ボードのサブタイトルまたは説明を入力
+Enter board title: ボードタイトルを入力
+Enter clip name: クリップ名を入力
+Enter clip note: クリップノートを入力
+Enter code: コードを入力
+Enter credit card number: クレジットカード番号を入力
+Enter default value: デフォルト値を入力
+Enter field value: フィールド値を入力
+Enter full path to file, folder or application: ファイル・フォルダー・アプリのフルパスを入力
+Enter regex for output filer: 出力フィルター用正規表現を入力
+Enter request url: リクエストURLを入力
+Enter secret value: シークレット値を入力
+Enter section label: セクションラベルを入力
+Enter select option: オプションを入力
+Enter tab name: タブ名を入力
+Enter template or drag from history: テンプレートを入力または履歴からドラッグ
+Enter template value: テンプレート値を入力
+Enter value or drag from history: 値を入力または履歴からドラッグ
+Enter web link or email: ウェブリンクまたはメールを入力
+Errors:
+  No fields found in the template.: テンプレートにフィールドが見つかりません。
+  Please fix output template or confirm to save as is.: 出力テンプレートを修正するか、そのまま保存を確認してください。
+  Please fix template fields or confirm to save as is.: テンプレートフィールドを修正するか、そのまま保存を確認してください。
+  Please fix the problem or confirm to save as is.: 問題を修正するか、そのまま保存を確認してください。
+  Please verify your link for any errors, or confirm to save as is.: リンクにエラーがないか確認するか、そのまま保存を確認してください。
+  Please verify your path for any errors, or confirm to save as is.: パスにエラーがないか確認するか、そのまま保存を確認してください。
+  Your command runs with errors, confirm you want to save as is.: コマンドにエラーがありますが、そのまま保存しますか？
+  Your request runs with errors, confirm you want to save as is.: リクエストにエラーがありますが、そのまま保存しますか？
+FILTERED_TYPES:
+  Dot Path: ドットパス
+  JSON Path: JSONパス
+  RegEx: 正規表現
+  RegEx Replace: 正規表現置換
+  Remove Quotes: クォート削除
+Field: フィールド
+Field Options: フィールドオプション
+Field {{name}} has been found in the template: フィールド{{name}}がテンプレートに見つかりました
+Fields Value: フィールド値
+File, folder or app path does not exist: ファイル・フォルダー・アプリのパスが存在しません
+File, folder or app path is valid: ファイル・フォルダー・アプリのパスは有効です
+File, folder or app path might not be valid: ファイル・フォルダー・アプリのパスが無効の可能性があります
+Fill Template: テンプレートを埋める
+Filter Type: フィルタータイプ
+Filter's Value: フィルター値
+Find in Clip: クリップ内検索
+Find in clip: クリップ内検索
+Find in history: 履歴内検索
+Flex Layout: フレックスレイアウト
+Form Fields: フォームフィールド
+General Fields: 一般フィールド
+Grid Layout: グリッドレイアウト
+HTML: HTML
+Headers: ヘッダー
+Hide Label: ラベルを非表示
+History capture is off: 履歴キャプチャはオフ
+Key Press: キー入力
+Key Press After: 後のキー入力
+Key Press After Paste: ペースト後のキー入力
+'Key Press After Paste: {{keyPress}}': 'ペースト後のキー入力: {{keyPress}}'
+Label Left: 左ラベル
+Label Top: 上ラベル
+Label on Left: 左側のラベル
+Labels: ラベル
+Last run: 最終実行
+Last update: 最終更新
+Layout Max Width: レイアウト最大幅
+Mask to hide clipboard value in preview: プレビューでクリップボード値を隠すマスク
+Move Clip: クリップを移動
+Moved Clips Panel: 移動したクリップパネル
+Name: 名前
+New Board: 新しいボード
+New Clip: 新しいクリップ
+No Boards: ボードなし
+No Clipboard History: クリップボード履歴なし
+No Tabs or Boards: タブまたはボードなし
+Number of columns: 列数
+Open: 開く
+Open URL Disable / Enable: URLオープン無効/有効
+Output Template: 出力テンプレート
+Panel for moved or copied items from other tabs: 他のタブから移動またはコピーしたアイテム用パネル
+Please confirm to save as is.: このまま保存してよろしいですか？
+Press: 押す
+RETURN_POSITION_TYPES:
+  First Only: 最初のみ
+  Last Only: 最後のみ
+RULES_TYPES:
+  CSS Selector: CSSセレクター
+  RegEx Find: 正規表現検索
+  RegEx Group Match: 正規表現グループ一致
+  RegEx Match: 正規表現一致
+  RegEx Replace: 正規表現置換
+RegEx Find: 正規表現検索
+RegEx Match: 正規表現一致
+RegEx Match Group: 正規表現グループ
+RegEx Replace: 正規表現置換
+Regex Match Group Filter: 正規表現グループフィルター
+Remove Open URL: URLオープンを削除
+Remove headers: ヘッダーを削除
+Remove image: 画像を削除
+Rename: 名前を変更
+Reset to Defaults: デフォルトにリセット
+Response Filters: レスポンスフィルター
+Result: 結果
+SEPARATOR_TYPES:
+  Comma (,): カンマ (,)
+  New Line (\n): 改行 (\n)
+  Pipe (|): パイプ (|)
+  Semicolon (;): セミコロン (;)
+  Space (' '): スペース (' ')
+  Tab (\t): タブ (\t)
+Save as Defaults: デフォルトとして保存
+Scan for Template Fields: テンプレートフィールドをスキャン
+Select Color: 色を選択
+Select Default Option: デフォルトオプションを選択
+Select Option: オプションを選択
+Select Options: オプションを選択
+Show Label: ラベルを表示
+Special Field: 特殊フィールド
+Subtitle: サブタイトル
+Tab: タブ
+Tab is Not Empty: タブは空ではありません
+Tabs Menu: タブメニュー
+Template: テンプレート
+Template Edit: テンプレート編集
+Template Fields: テンプレートフィールド
+Template should have⠀<b>{{output}}</b>⠀placeholder.: テンプレートには<b>{{output}}</b>プレースホルダーが必要です。
+Test Request: テストリクエスト
+Test Run: テスト実行
+Text: テキスト
+This action cannot be undone.: この操作は元に戻せません。
+This field allows to insert text from clipboard: このフィールドでクリップボードのテキストを挿入できます
+Too long: 長すぎます
+Too short: 短すぎます
+Turn On auto update: 自動更新をオン
+Turn on history capture: 履歴キャプチャをオン
+Type:
+  Command: コマンド
+  Request: リクエスト
+  Scraper: スクレイパー
+URL: URL
+Unsaved name: 未保存名
+Unsaved note: 未保存ノート
+Unsaved subtitle: 未保存サブタイトル
+Unsaved title: 未保存タイトル
+Update Link Card: リンクカードを更新
+Use double curly brackets for {{field name}}. Use {{clipboard}} to add current clipboard value.: {{field name}}は二重中括弧で。{{clipboard}}で現在のクリップボード値を追加。
+Value: 値
+Values: 値
+Vertical Split: 垂直分割
+We need to open a new window where you can drag & drop file, path or application.: 新しいウィンドウを開き、ファイル・パス・アプリをドラッグ＆ドロップできます。
+Web Link or Email might not be valid: ウェブリンクまたはメールが無効の可能性があります
+Web or Email link is valid: ウェブまたはメールリンクは有効です
+Website URL: ウェブサイトURL
+Website URL is valid: ウェブサイトURLは有効です
+Website URL might not be valid: ウェブサイトURLが無効の可能性があります
+Wrap output using {{output}} placeholder: {{output}}プレースホルダーで出力をラップ
+You have no rules added: ルールが追加されていません
+You'll need to clear this board of all clips and subboards before it can be deleted.: このボードを削除するには、すべてのクリップとサブボードをクリアする必要があります。
+You'll need to clear this tab of all boards before it can be deleted.: このタブを削除するには、すべてのボードをクリアする必要があります。
+filled template: 入力済みテンプレート
+new clips: 新しいクリップ
+template: テンプレート
+'{{count}} fields found in template but missing from fields definition._one': 'テンプレートに{{count}}個のフィールドが定義にありません。'
+'{{count}} fields found in template but missing from fields definition._other': 'テンプレートに{{count}}個のフィールドが定義にありません。'
+'{{count}} fields not found in the template._one': 'テンプレートに{{count}}個のフィールドが見つかりません。'
+'{{count}} fields not found in the template._other': 'テンプレートに{{count}}個のフィールドが見つかりません。'
+'{{type}} Field': '{{type}}フィールド'
+'{{type}} field': '{{type}}フィールド'

--- a/ja/help.yaml
+++ b/ja/help.yaml
@@ -1,0 +1,88 @@
+Add Menu Item: メニュー項目を追加
+App Guided Tours: アプリガイドツアー
+Board Panel: ボードパネル
+Board Panel Header: ボードパネルヘッダー
+Boards and Clips: ボードとクリップ
+Boards and Clips Tour: ボードとクリップツアー
+Clipboard History: クリップボード履歴
+Clipboard History Item: クリップボード履歴アイテム
+Clipboard History Panel: クリップボード履歴パネル
+Clipboard History Settings: クリップボード履歴設定
+Clipboard History Tour: クリップボード履歴ツアー
+Close Main Window: メインウィンドウを閉じる
+Collections Menu: コレクションメニュー
+Congratulations! You have finished <strong>all the tours</strong> and now ready to make the most of PasteBar's features. Remember, all tours always available from the <strong>Help > App Guided Tours</strong> menu in the navbar.: <strong>すべてのツアー</strong>を完了しました。PasteBarの機能を最大限に活用する準備ができました。すべてのツアーは常にナビゲーションバーの<strong>ヘルプ > アプリガイドツアー</strong>メニューから利用できます。
+Contact Us Form: お問い合わせフォーム
+Create Dashboard Items: ダッシュボードアイテムを作成
+Dashboard Panel: ダッシュボードパネル
+Dashboard Tabs: ダッシュボードタブ
+Done: 完了
+Feature Highlights: 機能のハイライト
+Feel free to explore the app on your own. If you need help or want to access the tours later, you can always find them in the <strong>Help > App Guided Tours</strong> menu in the navigation bar.: ご自由にアプリを探索してください。ヘルプが必要な場合や後でツアーにアクセスしたい場合は、ナビゲーションバーの<strong>ヘルプ > アプリガイドツアー</strong>メニューからいつでも見つけられます。
+Find Menu Items: メニュー項目を検索
+Find and Filter History: 履歴を検索・フィルタ
+Global Search: グローバル検索
+Got It: わかりました
+Great job! You have completed this tour. Ready to see more? Click <i>Skip</i> if you want to explore on your own. All tours always available from the <strong>Help > App Guided Tours</strong> menu in the navbar.: 素晴らしい！このツアーを完了しました。さらに見たい場合は<i>スキップ</i>をクリックしてください。すべてのツアーはナビゲーションバーの<strong>ヘルプ > アプリガイドツアー</strong>メニューからいつでも利用できます。
+Guided Tours Options: ガイドツアーオプション
+Help: ヘルプ
+Help Menu: ヘルプメニュー
+History Selected Items Menu: 履歴選択アイテムメニュー
+History/Menu Navigation Tabs: 履歴/メニューナビゲーションタブ
+Later: 後で
+Let's get started: はじめましょう
+Manage Collections Settings: コレクション設定を管理
+Manage Paste Menu Panel: ペーストメニューパネルを管理
+Mark All Completed: すべて完了にする
+Menu Item: メニュー項目
+Menu Item Tree: メニュー項目ツリー
+Navigation Bar: ナビゲーションバー
+Navigation Bar Menu: ナビゲーションバーメニュー
+Navigation Bar Tour: ナビゲーションバーツアー
+Next: 次へ
+Next Tour: 次のツアー
+Paste Menu: ペーストメニュー
+Paste Menu Panel: ペーストメニューパネル
+Paste Menu Tour: ペーストメニューツアー
+Paste Menu View: ペーストメニュー表示
+PasteBar Menu: PasteBarメニュー
+PasteBar Settings: PasteBar設定
+PasteBar Settings Tour: PasteBar設定ツアー
+PasteBar Tour: PasteBarツアー
+Previous: 前へ
+Priority Support: 優先サポート
+Reset All Tours: すべてのツアーをリセット
+Resizable Panel View: リサイズ可能なパネル表示
+Return to the Main Screen: メイン画面に戻る
+Saved Clip Item: 保存済みクリップアイテム
+Security Settings: セキュリティ設定
+Selected Items Paste Menu: 選択アイテムペーストメニュー
+Skip: スキップ
+Skip All Tours: すべてのツアーをスキップ
+Skip Tour: ツアーをスキップ
+Skip Update: アップデートをスキップ
+Start: 開始
+Start Next Tour: 次のツアーを開始
+Start Tour: ツアーを開始
+Support and Feedback: サポートとフィードバック
+Tabs and Layout Menu: タブとレイアウトメニュー
+Title on Popover: ポップオーバーのタイトル
+Toggle Inactive Menu Items: 非アクティブメニュー項目の切り替え
+Toggle Pinned Board: ピン留めボードの切り替え
+Toggle History Window: 履歴ウィンドウの切り替え
+Tour Completed: ツアー完了
+Tour Skipped: ツアースキップ
+Tour completed: ツアー完了
+Tour skipped: ツアースキップ
+TourCanSkip: ツアーをスキップ可能
+User Preferences: ユーザー設定
+View Menu: ビューメニュー
+Welcome to Paste Menu: ペーストメニューへようこそ
+Welcome to PasteBar: PasteBarへようこそ
+Welcome to PasteBar Settings: PasteBar設定へようこそ
+WelcomeBody: PasteBarでコピー＆ペースト作業を簡単にしましょう！このガイドツアーでは主な機能を紹介し、アプリの活用方法を案内します。まずはクリップボード履歴パネルを見てみましょう。
+WelcomeDescription: コピー＆ペースト作業の効率化とクリップボード機能強化のために当アプリをお選びいただきありがとうございます。PasteBarの機能を最大限に活用するため、簡単なツアーにご参加ください。
+WelcomeTour: まずはクリップボード履歴パネルを見てみましょう。
+WelcomeTourCanSkip: または<i>ツアーをスキップ</i>してご自身で探索することもできます。すべてのツアーはナビゲーションバーの<strong>ヘルプ > アプリガイドツアー</strong>メニューからいつでも利用できます。
+WelcomeTourDescription: このアプリのセクションの機能や使い方を学ぶためのツアーです。
+You have completed the tour: ツアーを完了しました

--- a/ja/history.yaml
+++ b/ja/history.yaml
@@ -1,0 +1,42 @@
+All History Settings: すべての履歴設定
+All done! History's been cleared.: 完了！履歴がクリアされました。
+Auto Update on Capture: キャプチャ時に自動更新
+Auto-Clear Settings: 自動クリア設定
+Capture History: 履歴をキャプチャ
+Clear: クリア
+Clear All: すべてクリア
+Clear All History: 履歴をすべてクリア
+Clear History: 履歴をクリア
+Confirm Clear All History: 履歴をすべてクリアしてもよろしいですか？
+Do you really want to remove ALL clipboard history items?: すべてのクリップボード履歴を本当に削除しますか？
+Do you want to remove all recent clipboard history older than {{olderThen}} {{durationType}}: {{olderThen}}{{durationType}}より古い最近のクリップボード履歴を削除しますか？
+Do you want to remove clipboard history items older than {{olderThen}} {{durationType}}: {{olderThen}}{{durationType}}より古いクリップボード履歴を削除しますか？
+Enable Capture History: 履歴キャプチャを有効化
+Enable Image Capture: 画像キャプチャを有効化
+Filters:
+  App Filters: アプリフィルター
+  Audio: オーディオ
+  Clear Filters: フィルターをクリア
+  Code: コード
+  Emoji: 絵文字
+  Image: 画像
+  Language Filters: 言語フィルター
+  Languages: 言語
+  Languages Filter: 言語フィルター
+  Languages Filters: 言語フィルター
+  Link: リンク
+  Pinned: ピン留め
+  Secret: シークレット
+  Select Filters: フィルターを選択
+  Source: ソース
+  Source Application: ソースアプリ
+  Source Filters: ソースフィルター
+  Starred: スター付き
+  Text: テキスト
+  Video: ビデオ
+Hide pinned history: ピン留め履歴を非表示
+History Settings: 履歴設定
+Paste Menu: ペーストメニュー
+Select Filters: フィルターを選択
+View pinned history: ピン留め履歴を表示
+'{{isAll}} Clipboard History': '{{isAll}}クリップボード履歴'

--- a/ja/menus.yaml
+++ b/ja/menus.yaml
@@ -1,0 +1,30 @@
+Add First Item: 最初の項目を追加
+Add Item: 項目を追加
+Add item: 項目を追加
+Close Edit: 編集を閉じる
+Create Menu: メニューを作成
+Delete Menu: メニューを削除
+Disabled Item: 無効な項目
+Disabled Menu: 無効なメニュー
+Drag items to reorder, double click to rename: 項目をドラッグして並べ替え、ダブルクリックで名前変更
+Enter menu label: メニューラベルを入力
+Find in menu: メニュー内検索
+Link to Clip: クリップにリンク
+Menu: メニュー
+Menu Item: メニュー項目
+Menu Options: メニューオプション
+Menu Type: メニュータイプ
+Menu is a link to a clip: メニューはクリップへのリンクです
+Menu is link to a clip and cannot be renamed. Please rename its linked clip.: メニューはクリップへのリンクのため名前変更できません。リンク先のクリップ名を変更してください。
+Menus: メニュー
+New Disabled Menu: 新しい無効メニュー
+New Menu: 新しいメニュー
+New Submenu: 新しいサブメニュー
+No Menu Items: メニュー項目なし
+No {{hasActive}} menu items in: {{hasActive}}のメニュー項目がありません
+Select item to add a menu after: 追加する位置の項目を選択
+Separator: セパレーター
+Submenu: サブメニュー
+Toggle inactive menu items: 非アクティブメニュー項目の切り替え
+active: アクティブ
+menu items in: メニュー項目

--- a/ja/navbar.yaml
+++ b/ja/navbar.yaml
@@ -1,0 +1,44 @@
+Attach History: 履歴を添付
+Audio Player: オーディオプレイヤー
+Close History: 履歴を閉じる
+Close Main Window: メインウィンドウを閉じる
+Color Theme: カラーテーマ
+GlobalSearch:
+  Auto Close on Copy & Paste: コピー＆ペースト時に自動で閉じる
+  Excludes clip or menu values: クリップやメニュー値を除外
+  Nothing found in boards.: ボードに何も見つかりません。
+  Nothing found in clips, boards or menus.: クリップ・ボード・メニューに何も見つかりません。
+  Nothing found in clips.: クリップに何も見つかりません。
+  Nothing found in menus.: メニューに何も見つかりません。
+  Press / key to search: /キーで検索
+  Search: 検索
+  Search Name or Label Only: 名前またはラベルのみ検索
+  Search Options: 検索オプション
+  Type what you looking for: 探したい内容を入力
+Help: ヘルプ
+Language: 言語
+Lock: ロック
+Lock App Screen: アプリ画面をロック
+Lock Screen: 画面ロック
+Open PasteBar: PasteBarを開く
+Options: オプション
+Player: プレイヤー
+Show Always on Top: 常に最前面に表示
+Show Both Panels: 両方のパネルを表示
+Show Clips Panel Only: クリップパネルのみ表示
+Show Collections Name: コレクション名を表示
+Show History Panel Only: 履歴パネルのみ表示
+Swap Panels Layout: パネルレイアウトを入れ替え
+Theme:
+  Dark: ダーク
+  Light: ライト
+  System: システム
+View: 表示
+Window:
+  Attach History Window: 履歴ウィンドウを添付
+  Attach Window: ウィンドウを添付
+  Close Window: ウィンドウを閉じる
+  Maximize Window: ウィンドウを最大化
+  Minimize Window: ウィンドウを最小化
+  Pin Window: ウィンドウをピン留め
+  UnPin Window: ウィンドウのピンを外す

--- a/ja/pinned.yaml
+++ b/ja/pinned.yaml
@@ -1,0 +1,3 @@
+Hide Pinned: ピン留めを非表示
+Pin: ピン留め
+Show Pinned: ピン留めを表示

--- a/ja/settings.yaml
+++ b/ja/settings.yaml
@@ -1,0 +1,220 @@
+<strong>{{screenLockPassCodeLength}}</strong>桁のパスコードが設定されています。: <strong>{{screenLockPassCodeLength}}</strong>桁のパスコードが設定されています。
+Activation Success: 有効化に成功しました
+Add a star to the copied text when you copy it twice within 1 second. This allows you to quickly add copied text or links to your favorites and easily find it in the clipboard history.: 1秒以内に2回コピーするとコピーしたテキストにスターを付けます。これによりお気に入りに素早く追加し、クリップボード履歴から簡単に見つけられます。
+Add an unlimited number of tabs within each collection for better organization and easy access.: 各コレクション内に無制限のタブを追加でき、整理やアクセスが容易になります。
+'Add an unlimited number of tabs within each collection for better organization and easy access.                                ': '各コレクション内に無制限のタブを追加でき、整理やアクセスが容易になります。'
+Advanced settings: 詳細設定
+Already Active: すでに有効です
+Application Auto Start: アプリ自動起動
+Application Color Theme: アプリカラーテーマ
+Application UI Color Theme: アプリUIカラーテーマ
+Application UI Fonts Scale: アプリUIフォントサイズ
+Application UI Language: アプリUI言語
+Applications listed below will not have their copy to clipboard action captured in clipboard history. Case insensitive.: 下記アプリはクリップボード履歴にコピー操作が記録されません（大文字小文字区別なし）。
+Apply and Restart: 適用して再起動
+Are you sure you want to go back to the default data folder? This will remove the custom location setting.: デフォルトのデータフォルダーに戻しますか？カスタム設定が削除されます。
+Are you sure you want to revert to the default database location? The application will restart.: デフォルトのデータベース場所に戻しますか？アプリが再起動します。
+Are you sure you want to set "{{path}}" as the new data folder? The application will restart.: "{{path}}"を新しいデータフォルダーに設定しますか？アプリが再起動します。
+Are you sure you want to {{operation}} the database to "{{path}}"? The application will restart.: データベースを"{{path}}"に{{operation}}しますか？アプリが再起動します。
+Auto Disable History Capture when Screen Unlocked: 画面ロック解除時に履歴キャプチャを自動無効化
+Auto Lock Application Screen on User Inactivity: ユーザー非操作時にアプリ画面を自動ロック
+Auto Lock Screen on User Inactivity: ユーザー非操作時に画面を自動ロック
+Auto Lock the Screen on User Inactivity: ユーザー非操作時に画面を自動ロック
+Auto Masking Words List: 自動マスキングワードリスト
+Auto update on capture: キャプチャ時に自動更新
+Auto-Clear Settings: 自動クリア設定
+Auto-Generate Link Card Preview: リンクカードプレビューを自動生成
+Auto-Preview Link on Hover: ホバー時にリンクを自動プレビュー
+Auto-Star on Double Copy: ダブルコピーで自動スター
+Auto-Trim Spaces on Capture: キャプチャ時に空白を自動トリム
+Auto-Update on Capture: キャプチャ時に自動更新
+Auto-delete clipboard history after: クリップボード履歴を自動削除
+Automatically create link card preview in the clipboard history. This allows to quickly view website details without opening or pasting the link.: クリップボード履歴にリンクカードプレビューを自動作成。リンクを開かずにウェブサイト詳細を素早く確認できます。
+Back: 戻る
+Capture History: 履歴をキャプチャ
+Capture History Text Length Limits: 履歴テキスト長制限
+Change Custom Data Folder...: カスタムデータフォルダーを変更...
+Change Directory...: ディレクトリを変更...
+Change Selected Folder...: 選択フォルダーを変更...
+Change the application UI font size scale: アプリUIフォントサイズを変更
+Change the application UI language: アプリUI言語を変更
+Change the application user interface color theme: アプリUIカラーテーマを変更
+Change the application user interface font size scale: アプリUIフォントサイズを変更
+Change the application user interface language: アプリUI言語を変更
+Changing the database location requires an application restart to take effect.: データベース場所の変更にはアプリ再起動が必要です。
+Clip Notes Popup Maximum Dimensions: クリップノートポップアップ最大サイズ
+Clipboard History Settings: クリップボード履歴設定
+'Complete details:': '詳細:'
+Configure settings to automatically delete clipboard history items after a specified duration.: 指定期間後にクリップボード履歴を自動削除する設定
+ConfirmRevertToDefaultDbPathMessage: デフォルトのデータ場所に戻しますか？アプリデータがデフォルトパスに移動されます。
+Copy data: データをコピー
+Copy database file: データベースファイルをコピー
+Create a preview card on link hover in the clipboard history. This allows you to preview the link before opening or pasting it.: クリップボード履歴でリンクにホバーするとプレビューカードを作成。開かずに内容を確認できます。
+Create an unlimited number of collections to organize your clips and menus.: クリップやメニューを整理するため無制限のコレクションを作成可能
+Current data folder: 現在のデータフォルダー
+Current data location: 現在のデータ場所
+Current database location: 現在のデータベース場所
+Custom: カスタム
+Custom Application Data Location: カスタムアプリデータ場所
+Custom Database Location: カスタムデータベース場所
+Custom data location is active. You can change it or revert to the default location. Changes require an application restart.: カスタムデータ場所が有効です。変更やデフォルトへの復元にはアプリ再起動が必要です。
+Custom themes: カスタムテーマ
+Decrease UI Font Size: UIフォントサイズを縮小
+Default: デフォルト
+Disable Image Capture: 画像キャプチャを無効化
+Disable capturing and storing images from clipboard: クリップボードからの画像取得・保存を無効化
+Display clipboard history capture toggle on the locked application screen. This allows you to control history capture settings directly from the lock screen.: ロック画面で履歴キャプチャ切り替えを表示。ロック画面から直接設定可能。
+Display disabled collections name on the navigation bar collections menu: ナビバーのコレクションメニューに無効コレクション名を表示
+Display disabled collections name on the navigation bar under collections menu: ナビバーのコレクションメニュー下に無効コレクション名を表示
+Display full name of selected collection on the navigation bar: 選択コレクションのフルネームをナビバーに表示
+Do you want to attempt to move the database file from "{{customPath}}" back to the default location?: "{{customPath}}"からデータベースファイルをデフォルト場所に戻しますか？
+Drag and drop to prioritize languages for detection. The higher a language is in the list, the higher its detection priority.: ドラッグ＆ドロップで検出優先言語を並べ替え。上位ほど優先度が高くなります。
+Email: メール
+Email is not valid: メールが無効です
+'Email:': 'メール:'
+Emails do not match: メールが一致しません
+Enable Auto Start: 自動起動を有効化
+Enable Clip Title Hover Show with Delay: クリップタイトルのホバー表示を遅延有効化
+Enable application auto start on system boot: システム起動時にアプリ自動起動を有効化
+Enable auto lock the application screen after a certain period of inactivity, to prevent unauthorized access to your data.: 一定時間操作がない場合にアプリ画面を自動ロックし、不正アクセスを防止
+Enable auto lock the application screen when user not active: ユーザー非操作時にアプリ画面を自動ロック
+Enable auto trim spaces on history capture: 履歴キャプチャ時に空白を自動トリム
+Enable auto update on capture: キャプチャ時に自動更新を有効化
+Enable custom data location to store application data in a directory of your choice instead of the default location.: デフォルト以外の任意ディレクトリにアプリデータを保存するカスタムデータ場所を有効化
+Enable history capture: 履歴キャプチャを有効化
+Enable programming language detection: プログラミング言語検出を有効化
+Enable screen unlock requirement on app launch for enhanced security, safeguarding data from unauthorized access.: アプリ起動時に画面ロック解除を必須にし、セキュリティを強化
+Enter Passcode length: パスコード桁数を入力
+Enter new directory path or leave empty for default on next revert: 新しいディレクトリパスを入力、または空欄で次回復元時にデフォルト
+Enter recovery password to reset passcode.: パスコードリセットには復旧用パスワードを入力
+Enter your <strong>{{screenLockPassCodeLength}} digits</strong> passcode: <strong>{{screenLockPassCodeLength}}桁</strong>のパスコードを入力
+Entered Passcode is invalid: 入力したパスコードが無効です
+Excluded Apps List: 除外アプリリスト
+Execute Web Requests: Webリクエストを実行
+Execute terminal or shell commands directly from PasteBar clip and copy the results to the clipboard.: PasteBarクリップから直接ターミナルやシェルコマンドを実行し、結果をクリップボードにコピー
+'Expires:': '有効期限:'
+Failed to revert to default database location.: デフォルトのデータベース場所への復元に失敗しました
+Failed to select directory: ディレクトリの選択に失敗しました
+Forgot Passcode ? Enter your recovery password to reset the passcode.: パスコードを忘れた場合は復旧用パスワードを入力してリセット
+Forgot passcode ?: パスコードを忘れましたか？
+Forgot?: 忘れた？
+Forgot? Reset using Password: 忘れた？パスワードでリセット
+Get priority email support from us to resolve any issues or questions you may have about PasteBar.: PasteBarに関するご質問や問題は優先メールサポートをご利用ください
+'Hint: {{screenLockRecoveryPasswordMasked}}': 'ヒント: {{screenLockRecoveryPasswordMasked}}'
+If a database file already exists at the default location, do you want to overwrite it? Choosing "Cancel" will skip moving the file if an existing file is found.: デフォルト場所に既存のデータベースファイルがある場合、上書きしますか？「キャンセル」で既存ファイルがある場合は移動をスキップします。
+Incorrect passcode.: パスコードが間違っています
+Increase UI Font Size: UIフォントサイズを拡大
+Issued: 発行日
+Large: 大
+List each application name or window identifier on a new line.: 各アプリ名またはウィンドウ識別子を1行ずつ記載
+List each word or sentence on a new line.: 各単語または文を1行ずつ記載
+Lock Screen Clipboard History Capture Control: ロック画面で履歴キャプチャ制御
+Lock Screen PassCode: ロック画面パスコード
+Lock Screen Passcode: ロック画面パスコード
+Manage Collections: コレクションを管理
+Maximum 10 digits: 最大10桁
+Maximum devices: 最大デバイス数
+Medium: 中
+Minimal 4 digits: 最小4桁
+Minimize Window: ウィンドウを最小化
+Minimum number of lines to trigger detection: 検出を開始する最小行数
+Move data: データを移動
+Move database file: データベースファイルを移動
+Name: 名前
+New Data Directory Path: 新しいデータディレクトリパス
+New Database Directory Path: 新しいデータベースディレクトリパス
+Open Security Settings: セキュリティ設定を開く
+Operation when applying new path: 新しいパス適用時の操作
+Passcode digits remaining: 残りパスコード桁数
+Passcode is locked.: パスコードがロックされています
+Passcode is not set: パスコードが未設定
+Passcode is not valid: パスコードが無効です
+Passcode length: パスコード桁数
+Passcode mismatch: パスコード不一致
+Passcode reset is locked.: パスコードリセットがロックされています
+Passcode successfully verified: パスコードが正常に認証されました
+Passcode verification error: パスコード認証エラー
+Passcode verification is locked.: パスコード認証がロックされています
+Password is incorrect.: パスワードが間違っています
+Password is incorrect. <br/>{{screenLockRecoveryPasswordMasked}}: パスワードが間違っています。<br/>{{screenLockRecoveryPasswordMasked}}
+'Password is incorrect. Hint: {{screenLockRecoveryPasswordMasked}}': 'パスワードが間違っています。ヒント: {{screenLockRecoveryPasswordMasked}}'
+'Password is incorrect. Masked password is: {{screenLockRecoveryPasswordMasked}}': 'パスワードが間違っています。マスクされたパスワード: {{screenLockRecoveryPasswordMasked}}'
+Password is incorrect. {{screenLockRecoveryPasswordMasked}}: パスワードが間違っています。{{screenLockRecoveryPasswordMasked}}
+Passwords do not match: パスワードが一致しません
+PasteBar Settings: PasteBar設定
+Pin Window: ウィンドウをピン留め
+Pin on Top Window: 最前面にピン留め
+Please set up a Passcode and recovery password in Security Settings to enable Screen Lock and ensure better security.: セキュリティ設定でパスコードと復旧用パスワードを設定し、画面ロックとセキュリティ強化を有効にしてください。
+Please try again: もう一度お試しください
+Preview current popup size on hover.: ホバー時に現在のポップアップサイズをプレビュー
+Prioritize Language Detection: 言語検出の優先順位付け
+Priority support: 優先サポート
+Programming Language Detection: プログラミング言語検出
+Programming Language Selection: プログラミング言語選択
+Protect your data by requiring screen unlock authentication whenever the application starts.: アプリ起動時に画面ロック解除認証を必須にし、データを保護
+Recovery Password for Lock Screen Passcode: ロック画面パスコードの復旧用パスワード
+Recovery password is set.: 復旧用パスワードが設定されています
+Refresh Application UI: アプリUIをリフレッシュ
+Refresh UI: UIをリフレッシュ
+Require Screen Unlock at Application Start: アプリ起動時に画面ロック解除を必須にする
+Require screen unlock at application launch to enhance security. This setting ensures that only authorized users can access the application, protecting your data from unauthorized access right from the start.: アプリ起動時に画面ロック解除を必須にし、セキュリティを強化します。この設定により認証済みユーザーのみがアプリにアクセスでき、データを保護します。
+Reset Font Size: フォントサイズをリセット
+Revert to Default: デフォルトに戻す
+Revert to Default and Restart: デフォルトに戻して再起動
+Run Terminal or Shell Commands: ターミナルやシェルコマンドを実行
+Scrape and parse websites or API responses using built-in web scraping tools and copy the extracted data to the clipboard.: 内蔵のWebスクレイピングツールでWebサイトやAPIレスポンスを抽出し、クリップボードにコピー
+'Scrape and parse websites or API responses using built-in web scraping tools and copy the extracted data to the clipboard.                                ': 内蔵のWebスクレイピングツールでWebサイトやAPIレスポンスを抽出し、クリップボードにコピー
+Security: セキュリティ
+Security Settings: セキュリティ設定
+Select Custom Data Folder...: カスタムデータフォルダーを選択...
+Select Data Folder: データフォルダーを選択
+Select Data Folder...: データフォルダーを選択...
+Select a custom location to store your application data instead of the default location.: デフォルト以外の場所にアプリデータを保存するカスタム場所を選択
+Selected data folder: 選択したデータフォルダー
+Selected new data folder: 新しいデータフォルダーを選択
+Selected new data folder for change: 変更用の新しいデータフォルダーを選択
+Send HTTP requests to web APIs or services and copy the response data to the clipboard.: Web APIやサービスにHTTPリクエストを送り、レスポンスデータをクリップボードにコピー
+Sensitive words or sentences listed below will automatically be masked if found in the copied text. Case insensitive.: 下記の単語や文がコピーしたテキストに含まれる場合、自動的にマスクされます（大文字小文字区別なし）。
+Set a passcode to unlock the locked screen and protect your data from unauthorized access.: ロック画面解除用のパスコードを設定し、不正アクセスからデータを保護
+Set a recovery password to easily reset your lock screen passcode if forgotten. Your password will be securely stored in your device's OS storage.: パスコードを忘れた場合に簡単にリセットできる復旧用パスワードを設定。パスワードは端末のOSストレージに安全に保存されます。
+Setting a custom database location requires an application restart to take effect.: カスタムデータベース場所の設定にはアプリ再起動が必要です。
+Settings: 設定
+Show Clipboard History Capture Control on Lock Screen: ロック画面で履歴キャプチャ制御を表示
+Show Disable History Capture When Screen Locked: 画面ロック時に履歴キャプチャ無効を表示
+Show Disabled Collections: 無効コレクションを表示
+Show clipboard history capture toggle when the application screen is locked. This allow you to control capturing history settings from the application locked screen.: アプリ画面ロック時に履歴キャプチャ切り替えを表示。ロック画面から直接制御可能。
+Show collection name on the navbar: ナビバーにコレクション名を表示
+Show disabled collections on the navbar list: ナビバーリストに無効コレクションを表示
+Skip auto start prompt on app launch: アプリ起動時の自動起動プロンプトをスキップ
+Small: 小
+Stop Words List: ストップワードリスト
+Swap Panels Layout: パネルレイアウトを入れ替え
+Switch the layout position of panels in Clipboard History and Paste Menu views: クリップボード履歴とペーストメニューのパネル位置を切り替え
+Thank you again for using PasteBar.: PasteBarをご利用いただきありがとうございます。
+Thank you for testing! 🙌: テストありがとうございます！
+The selected folder is not empty and does not contain PasteBar data files. Do you want to create a "pastebar-data" subfolder to store the data?: 選択したフォルダーが空でなくPasteBarデータファイルが含まれていません。「pastebar-data」サブフォルダーを作成してデータを保存しますか？
+The selected folder is not empty. Do you want to create a "pastebar-data" subfolder to store the data?: 選択したフォルダーが空でありません。「pastebar-data」サブフォルダーを作成してデータを保存しますか？
+This folder already contains PasteBar data. The application will use this existing data after restart.: このフォルダーには既にPasteBarデータが含まれています。アプリ再起動後に既存データが使用されます。
+This option lets you control the display and timing of hover notes on clips. You can choose to show notes instantly or with a delay to prevent unintended popups.: このオプションでクリップのホバーノート表示とタイミングを制御できます。即時表示や遅延表示を選択可能です。
+This option lets you customize the maximum width and height of the popup that displays clip notes, ensuring it fits comfortably within your desired size.: このオプションでクリップノート表示ポップアップの最大幅・高さをカスタマイズできます。
+This option lets you customize the minimum and maximum length of text that can be captured in the clipboard history. Setting either value to 0 makes that limit unlimited.: このオプションでクリップボード履歴に記録できるテキストの最小・最大長をカスタマイズできます。0に設定すると無制限になります。
+To downgrade your current version, please visit: 現在のバージョンをダウングレードするにはこちらをご覧ください
+'To downgrade, please visit: ': ダウングレードはこちら: 
+To ensure the best detection accuracy, please select up to 7 languages. Limiting choices improves precision.: 最適な検出精度のため最大7言語まで選択してください。選択数を絞ると精度が向上します。
+Today: 今日
+Tomorrow: 明日
+Try after <strong>{{resetPassCodeNextDelay}}</strong> seconds: <strong>{{resetPassCodeNextDelay}}</strong>秒後に再試行
+Try again after <strong>{{resetPassCodeNextDelay}}</strong> seconds: <strong>{{resetPassCodeNextDelay}}</strong>秒後に再試行
+UI Language: UI言語
+UnPin Window: ウィンドウのピンを外す
+Unlimited Collections: 無制限のコレクション
+Unlimited Tabs per Collection: コレクションごとに無制限のタブ
+Unlimited paste history: 無制限のペースト履歴
+Use Password: パスワードを使用
+Use new location: 新しい場所を使用
+User Preferences: ユーザー設定
+Web Scraping and Parsing: Webスクレイピングとパース
+Words or sentences listed below will not be captured in clipboard history if found in the copied text. Case insensitive.: 下記の単語や文がコピーしたテキストに含まれる場合、履歴に記録されません（大文字小文字区別なし）。
+none: なし
+passcode reset: パスコードリセット
+password reset: パスワードリセット

--- a/ja/settings2.yaml
+++ b/ja/settings2.yaml
@@ -1,0 +1,82 @@
+App restart required: アプリの再起動が必要です
+Application Starts with Main Window Hidden: アプリはメインウィンドウ非表示で起動
+Auto-close window after action: 操作後にウィンドウを自動で閉じる
+Boards, saved clips and menu items panel visible: ボード・保存クリップ・メニュー項目パネルが表示
+Both clipboard history and saved clips panels visible: クリップボード履歴と保存クリップの両パネルが表示
+Change: 変更
+Click Set/Change button to start recording: 設定/変更ボタンをクリックして記録開始
+Clipboard history panel visible: クリップボード履歴パネルが表示
+Configure how the system tray icon responds to mouse clicks: システムトレイアイコンのマウスクリック動作を設定
+Configure the behavior of the Quick Paste window when selecting items: クイックペーストウィンドウの項目選択時の動作を設定
+Configure which items to preserve when clearing clipboard history (both manual and auto-clear operations).: 履歴クリア時（手動・自動）に保持する項目を設定
+Control which panels are visible in the main window: メインウィンドウで表示するパネルを制御
+Copy items only (no auto-paste): 項目をコピーのみ（自動ペーストなし）
+Copy only from menu items: メニュー項目からのみコピー
+Default Note Icon Type: デフォルトノートアイコンタイプ
+Disable left-click context menu: 左クリックのコンテキストメニューを無効化
+Display navbar items only when the mouse hovers over the navigation bar to minimize visible UI elements: ナビバーにマウスを乗せたときのみナビバー項目を表示し、UI要素を最小化
+Display persistent icons on clips that have notes to improve visual organization and make notes easier to discover.: ノート付きクリップに常時アイコンを表示し、視覚的整理とノート発見を容易に
+Double-click toggles app visibility: ダブルクリックでアプリの表示切替
+Double-clicking the tray icon shows or hides the main application window: トレイアイコンをダブルクリックでメインウィンドウを表示/非表示
+Enable simplified, less boxy layout for a cleaner and more streamlined interface design: シンプルで洗練されたレイアウトを有効化
+Enable single-click to copy/paste clipboard history items and saved clips instead of requiring double-click.: クリップボード履歴や保存クリップをダブルクリック不要でシングルクリックでコピー/ペースト
+Enabling either left-click option will disable the context menu to ensure proper functionality.: いずれかの左クリックオプションを有効にすると、正しく動作するためコンテキストメニューが無効になります
+Global System OS Hotkeys: グローバルシステムOSホットキー
+Hide Collections Navbar: コレクションナビバーを非表示
+Hide collections menu dropdown on the navigation bar: ナビバーのコレクションメニューをドロップダウン非表示
+Hide collections menu on the navbar: ナビバーのコレクションメニューを非表示
+Hide the App Dock Icon: アプリDockアイコンを非表示
+History Item Preview Max Lines: 履歴アイテムプレビュー最大行数
+'How to set hotkeys:': 'ホットキーの設定方法:'
+Keep Items on Clear: クリア時に項目を保持
+Keep Pinned Items: ピン留め項目を保持
+Keep Starred Items: スター付き項目を保持
+? Keep the main application window hidden when the app restarts. You can reopen it using the menu bar or taskbar menu, or using global hotkeys.
+: アプリ再起動時にメインウィンドウを非表示のままにします。メニューバーやタスクバー、グローバルホットキーで再表示できます。
+Left-click toggles app visibility: 左クリックでアプリの表示切替
+Left-clicking the tray icon shows or hides the main application window: トレイアイコンを左クリックでメインウィンドウを表示/非表示
+No keys set: キーが設定されていません
+'Note: At least one panel must remain visible in main window.': '注意: メインウィンドウには最低1つのパネルが表示されている必要があります。'
+Panel Visibility: パネル表示
+PasteBar Quick Paste: PasteBarクイックペースト
+Preserve pinned items when clearing history: 履歴クリア時にピン留め項目を保持
+Preserve starred items when clearing history: 履歴クリア時にスター付き項目を保持
+Press Backspace/Delete to clear the hotkey: バックスペース/デリートでホットキーをクリア
+Press Enter to confirm or Escape to cancel: Enterで確定、Escでキャンセル
+Press keys: キーを押してください
+Press your desired key combination (e.g., Ctrl+Shift+V): 希望のキー組み合わせを押してください（例: Ctrl+Shift+V）
+Press your key combination...: キー組み合わせを押してください...
+Prevents the context menu from appearing when left-clicking the tray icon: トレイアイコン左クリック時のコンテキストメニュー表示を防止
+Preview Max Lines: プレビュー最大行数
+Quick Paste Window: クイックペーストウィンドウ
+Quick Paste Window Options: クイックペーストウィンドウオプション
+Recording...: 記録中...
+? Remove PasteBar app icon from the macOS Dock while keeping the app running in the background. The app remains accessible via the menu bar icon. Requires an app restart to take effect.
+: macOS DockからPasteBarアイコンを非表示にし、アプリはバックグラウンドで動作します。メニューバーアイコンからアクセス可能。アプリ再起動が必要です。
+Set: 設定
+Set system OS hotkeys to show/hide the main app window and quick paste window. Supports up to 3-key combinations.: システムOSホットキーでメインウィンドウやクイックペーストウィンドウの表示/非表示を切り替え。最大3キー組み合わせ対応。
+Set the maximum number of lines to display in the preview of a history item: 履歴アイテムプレビューの最大表示行数を設定
+Show Boards and Clips Panel Only: ボード・クリップパネルのみ表示
+Show Both Panels: 両方のパネルを表示
+Show History Panel Only: 履歴パネルのみ表示
+Show Navbar Items Hover: ナビバー項目をホバー時のみ表示
+Show Note Icons on Clips: クリップにノートアイコンを表示
+Show Simplified Layout: シンプルレイアウトを表示
+Show collections menu on the navbar: ナビバーにコレクションメニューを表示
+Show navbar elements on hover only: ナビバー要素をホバー時のみ表示
+Show/Hide Main App Window: メインアプリウィンドウの表示/非表示
+Show/Hide Quick Paste Window: クイックペーストウィンドウの表示/非表示
+Simplified Panel Layout: シンプルパネルレイアウト
+Single Click Copy/Paste: シングルクリックでコピー/ペースト
+Single Click Copy/Paste action: シングルクリックでコピー/ペースト動作
+Set keyboard focus with a single click. Disables single-click copy/paste if set.: シングルクリックでキーボードフォーカスを設定（設定時はシングルクリックコピー/ペースト無効）
+Single-Click Keyboard Focus: シングルクリックでキーボードフォーカス
+This sets the default icon type for new clips with notes. You can customize individual clips via the context menu.: ノート付き新規クリップのデフォルトアイコンタイプを設定。個別クリップはコンテキストメニューでカスタマイズ可能。
+Tray Icon Behavior on Windows: Windowsでのトレイアイコン動作
+? When enabled, clicking menu items will only copy content to clipboard instead of auto-pasting. This gives you more control over when and where content is pasted.
+: 有効時はメニュー項目クリックで内容をクリップボードにコピーのみ（自動ペーストなし）。ペーストタイミングと場所を制御できます。
+? When enabled, clicking or pressing Enter on items in Quick Paste window will only copy them to clipboard without automatically pasting.
+: 有効時はクイックペーストウィンドウの項目クリックやEnter押下でクリップボードにコピーのみ（自動ペーストなし）。
+? When enabled, single click will copy/paste items in Quick Paste window. If global single click is also enabled, both settings work together.
+: 有効時はクイックペーストウィンドウでシングルクリックでコピー/ペースト。グローバル設定も有効なら両方連動。
+When enabled, the Quick Paste window will automatically close after copying or pasting an item.: 有効時はコピー/ペースト後にクイックペーストウィンドウが自動で閉じます。

--- a/ja/specailCopyPaste.yaml
+++ b/ja/specailCopyPaste.yaml
@@ -1,0 +1,1 @@
+Special Settings: 特別設定

--- a/ja/specialCopyPaste.yaml
+++ b/ja/specialCopyPaste.yaml
@@ -1,0 +1,74 @@
+Add Current Date/Time: 現在の日付/時刻を追加
+Add Line Numbers: 行番号を追加
+Add One Line Feed: 1行改行を追加
+Add Two Line Feeds: 2行改行を追加
+Base64 Decode: Base64デコード
+Base64 Encode: Base64エンコード
+CSV: CSV
+CSV to JSON: CSVをJSONに変換
+CSV to Markdown Table: CSVをMarkdownテーブルに変換
+Capitalize Case: 先頭大文字化
+Code Formatting: コード整形
+Count Characters: 文字数をカウント
+Count Lines: 行数をカウント
+Count Sentences: 文数をカウント
+Count Words: 単語数をカウント
+Data Conversion: データ変換
+Drag and drop category to prioritize its order in the special copy/paste menu.: 特別コピー/ペーストメニューでカテゴリの順序をドラッグ＆ドロップで優先付け
+Enable All: すべて有効化
+Enable special text transformation options for clipboard history items: クリップボード履歴アイテムの特別なテキスト変換オプションを有効化
+Enabled Operations: 有効な操作
+Encode/Decode: エンコード/デコード
+Format Converter: フォーマット変換
+HTML: HTML
+HTML Decode: HTMLデコード
+HTML Encode: HTMLエンコード
+HTML to Markdown: HTMLをMarkdownに変換
+HTML to Plain Text: HTMLをプレーンテキストに変換
+HTML to React Component: HTMLをReactコンポーネントに変換
+HTML to React JSX: HTMLをReact JSXに変換
+HTML to Text: HTMLをテキストに変換
+JSON: JSON
+JSON Stringify: JSON文字列化
+JSON to CSV: JSONをCSVに変換
+JSON to Markdown Table: JSONをMarkdownテーブルに変換
+JSON to TOML: JSONをTOMLに変換
+JSON to XML: JSONをXMLに変換
+JSON to YAML: JSONをYAMLに変換
+Markdown: Markdown
+Markdown to HTML: MarkdownをHTMLに変換
+Markdown to Text: Markdownをテキストに変換
+Operations: 操作
+PascalCase: パスカルケース
+Prioritize Category Order: カテゴリ順序を優先
+PrioritizeCategoryOrderNote: カテゴリ順序優先の注意
+Remove Duplicate Lines: 重複行を削除
+Remove Extra Spaces: 余分な空白を削除
+Remove Line Feeds: 改行を削除
+Reverse Text: テキストを逆順に
+Select Operations: 操作を選択
+Sentence case: 文頭大文字化
+Sort Lines Alphabetically: 行をアルファベット順に並べ替え
+Special Copy: 特別コピー
+Special Copy/Paste Operations: 特別コピー/ペースト操作
+Special Paste: 特別ペースト
+Special Settings: 特別設定
+TOML: TOML
+TOML to JSON: TOMLをJSONに変換
+Text Case: テキストの大文字小文字変換
+Text Tools: テキストツール
+Title Case: タイトルケース
+Trim White Space: 余分な空白をトリム
+UPPER CASE: 大文字
+URL Decode: URLデコード
+URL Encode: URLエンコード
+Whitespace & Lines: 空白と行
+XML: XML
+XML to JSON: XMLをJSONに変換
+YAML: YAML
+YAML to JSON: YAMLをJSONに変換
+camelCase: キャメルケース
+iNVERT cASE: 大小文字反転
+kebab-case: ケバブケース
+lower case: 小文字
+snake_case: スネークケース

--- a/ja/templates.yaml
+++ b/ja/templates.yaml
@@ -1,0 +1,24 @@
+Create New Template: 新しいテンプレートを作成
+Create Template: テンプレートを作成
+Enter template content...: テンプレート内容を入力...
+Enter template name (e.g., "signature", "email"): テンプレート名を入力（例: "signature", "email"）
+Global: グローバル
+Global Template: グローバルテンプレート
+Global Templates: グローバルテンプレート一覧
+Preview usage: 使用例をプレビュー
+Template Usage: テンプレートの使い方
+Template name already exists: テンプレート名は既に存在します。別の名前を選んでください。
+Template name cannot be changed after creation. Delete and recreate to change name.: テンプレート名は作成後に変更できません。変更するには削除して再作成してください。
+Use Global Template: グローバルテンプレートを使用
+addTemplateButton: テンプレートを追加
+confirmDeleteTemplateMessage: グローバルテンプレート「{{name}}」を削除してもよろしいですか？
+confirmDeleteTemplateTitle: 削除の確認
+deleteTemplateButtonTooltip: テンプレートを削除
+enableGlobalTemplatesLabel: グローバルテンプレートを有効化
+globalTemplatesDescription: どのクリップにも{{template_name}}で挿入できる再利用可能なテキストスニペットを管理します。
+globalTemplatesTitle: グローバルテンプレート
+templateEnabledLabel: 有効
+templateNameLabel: 名前
+templateValueLabel: 値
+localTemplateConflictWarning: グローバルテンプレート「{{label}}」も存在します。このクリップ内ではローカルテンプレートが優先されます。
+noGlobalTemplatesYet: まだグローバルテンプレートが定義されていません。「テンプレートを追加」をクリックして作成してください。

--- a/ja/tours.yaml
+++ b/ja/tours.yaml
@@ -1,0 +1,241 @@
+HISTORY_PANEL_TOUR:
+  - element: '#side-panel_tour'
+    popover:
+      title: クリップボード履歴パネル
+      description: このパネルにはコピーしたクリップボード履歴が表示され、後で簡単にアクセスできます。履歴をスクロールしたり、検索やタイプ別フィルタが可能です。パネルサイズも調整できます。
+      prefferedSide: 右
+  - element: '#history-find_tour'
+    popover:
+      title: 履歴検索・フィルタ
+      description: 検索機能でクリップボード履歴から特定の項目を素早く見つけられます。タイプ（テキスト・画像・リンク）でフィルタし、再コピーやボード保存も可能です。
+      prefferedSide: 下
+      alignment: 中央
+  - element: '#history-list_tour .history-item'
+    popover:
+      title: クリップボード履歴アイテム
+      description: 履歴内の各アイテムは過去にコピーした内容です。<b>ダブルクリック</b>やアイコンクリックで再コピー、<b>ドラッグ</b>でボードに保存、<b>右クリック</b>で詳細メニューが利用できます。
+      prefferedSide: 右
+  - element: '#tabs-history_tour'
+    meta:
+      closeTourCssPosition: 非表示
+    popover:
+      title: 履歴/メニューナビゲーションタブ
+      description: クリップボード履歴とペーストメニューを切り替えて管理・アクセスできます。
+      alignment: 中央
+      prefferedSide: 上
+  - element: '#history-menu-button_tour'
+    meta:
+      closeTourCssPosition: 非表示
+    popover:
+      title: 履歴選択アイテムメニュー
+      description: 履歴内の複数選択アイテムを管理できます。<b>複数選択</b>、全解除、ボード追加、削除、日付別クリアなどが可能です。
+      alignment: 終端
+      prefferedSide: 右
+  - element: .panel-resize_tour
+    popover:
+      title: リサイズ可能なパネル表示
+      description: パネルの端にマウスを合わせてリサイズカーソルが出たら<b>クリック＆ドラッグ</b>でサイズ調整できます。
+      prefferedSide: 右
+
+DASHBOARD_CLIPS_TOUR:
+  - element: .clips-dashboard-panel_tour
+    meta:
+      closeTourCssPosition: 非表示
+    popover:
+      title: ダッシュボードパネル
+      description: 保存クリップを整理・管理するハブです。カスタムタブやボードで構成し、履歴からドラッグで新規クリップ作成も可能。タブでカテゴリ切替もできます。
+      prefferedSide: 左
+  - element: '#dashboard-tabs_tour'
+    popover:
+      title: ダッシュボードタブ
+      description: カスタムタブを作成し、ダッシュボード内の各セクションを切り替えて管理できます。
+      alignment: 中央
+      prefferedSide: 下
+  - element: '#dashboard-tabs-create-button_tour'
+    popover:
+      title: ダッシュボードアイテム作成
+      description: 新しいクリップ・ボード・タブを追加してダッシュボードをカスタマイズできます。
+      alignment: 終端
+      prefferedSide: 下
+  - element: '#dashboard-tabs-context-menu_tour'
+    popover:
+      title: タブとレイアウトメニュー
+      description: タブを右クリックまたはメニューアイコンでレイアウト管理やタブ編集が可能。ワークフローに合わせてカスタマイズできます。
+      alignment: 終端
+      prefferedSide: 下
+  - element: .board-panel_tour
+    popover:
+      title: ボードパネル
+      description: 保存クリップを素早く整理・アクセスできるパネルです。履歴からドラッグで追加、ボードでカテゴリ分けも可能。
+      alignment: 中央
+      prefferedSide: 右
+  - element: .board-panel-header_tour
+    popover:
+      title: ボードパネルヘッダー
+      description: <b>ダブルクリック</b>でパネル拡大、<b>右クリック</b>でカスタマイズや管理オプションが表示されます。
+      alignment: 開始
+      prefferedSide: 右
+  - element: .clip_tour
+    popover:
+      title: 保存済みクリップアイテム
+      description: 保存クリップに素早くアクセス。<b>ダブルクリック</b>やクリップボードアイコンでコピー、<b>長押し</b>で並べ替え、<b>右クリック</b>で詳細オプション。
+      alignment: 開始
+      prefferedSide: 右
+  - element: .panel-resize_tour
+    popover:
+      title: リサイズ可能なパネル表示
+      description: パネルの端にマウスを合わせてリサイズカーソルが出たら<b>クリック＆ドラッグ</b>でサイズ調整できます。
+      prefferedSide: 右
+
+MENU_TOUR:
+  - element: '#side-panel_tour'
+    popover:
+      title: ペーストメニューパネル
+      description: システムのタスクバーやメニューバーのネイティブペーストメニューを管理できます。<b>ドラッグ</b>で並べ替え、<b>ダブルクリック</b>で名前変更、ALTやCommandキー＋クリックで複数選択。
+      prefferedSide: 右
+  - element: '#menu-find_tour'
+    popover:
+      title: メニュー項目検索
+      description: 検索バーで特定のメニュー項目を素早く検索。キーワード入力で絞り込み。
+      prefferedSide: 下
+      alignment: 中央
+  - element: div[role=treeitem]
+    popover:
+      title: メニュー項目ツリー
+      description: 各メニュー項目は個別またはグループで並べ替え可能。<b>ダブルクリック</b>で名前変更、<b>ドラッグ</b>で並べ替え、ALTやCommand＋クリックで複数選択。
+      prefferedSide: 右
+  - element: '#tabs-menu_tour'
+    meta:
+      closeTourCssPosition: 非表示
+    popover:
+      title: 履歴/メニューナビゲーションタブ
+      description: クリップボード履歴とペーストメニューを切り替えて管理・アクセスできます。
+      alignment: 中央
+      prefferedSide: 上
+  - element: '#menu-icon-menu-button_tour'
+    meta:
+      closeTourCssPosition: 非表示
+    popover:
+      title: 選択アイテムペーストメニュー
+      description: 複数選択したメニュー項目を管理。全解除、ネイティブメニュー再構築、削除などで素早く整理。
+      alignment: 終端
+      prefferedSide: 右
+  - element: '#menu-main-list_tour'
+    meta:
+      closeTourCssPosition: 非表示
+    popover:
+      title: ペーストメニューパネル管理
+      description: すべてのアクティブなメニュー項目を管理。追加・編集・削除や既存クリップのリンクも可能。<b>ダブルクリック</b>でコピー、<b>右クリック</b>で詳細オプション。
+      alignment: 開始
+      prefferedSide: 左
+  - element: .menu-item_tour
+    popover:
+      title: メニュー項目
+      description: 各メニュー項目を個別に管理。<b>展開アイコン</b>で内容表示、<b>ダブルクリック</b>でコピー、<b>右クリック</b>で詳細オプション。
+      alignment: 中央
+      prefferedSide: 下
+  - element: '#add-menu-item__tour'
+    popover:
+      title: メニュー項目追加
+      description: プラスアイコンをクリックし、追加位置を選択。新規メニュー・サブメニュー・セパレーター・無効項目・履歴から・クリップリンクなど作成可能。
+      alignment: 終端
+      prefferedSide: 下
+  - element: '#toggle-inactive-menu-items_tour'
+    popover:
+      title: 非アクティブメニュー項目の切り替え
+      description: このアイコンで非アクティブ項目の表示/非表示を切り替え。必要な項目に集中し、作業効率を向上。
+      alignment: 開始
+      prefferedSide: 下
+  - element: .panel-resize_tour
+    popover:
+      title: リサイズ可能なパネル表示
+      description: パネルの端にマウスを合わせてリサイズカーソルが出たら<b>クリック＆ドラッグ</b>でサイズ調整できます。
+      prefferedSide: 右
+
+NAVBAR_TOUR:
+  - element: '#navbar-panel_tour'
+    popover:
+      title: ナビゲーションバー
+      description: ナビゲーションバーはPasteBarの機能や設定へのクイックアクセスを提供します。履歴・ペーストメニュー切替、コレクション・検索・ピンボード・設定・ヘルプなどに素早くアクセス。
+      alignment: 中央
+      prefferedSide: 下
+  - element: '#navbar-pastebar_tour'
+    popover:
+      title: PasteBarメニュー
+      description: PasteBarメニューから主要機能や情報に素早くアクセス。アップデート確認・設定・画面ロック・ウィンドウ閉じる・アプリ終了など。
+      alignment: 開始
+      prefferedSide: 下
+  - element: '#navbar-view_tour'
+    popover:
+      title: ビューメニュー
+      description: ビューメニューで履歴・ペーストメニューの切替、オプション・カラーテーマ・UIフォントサイズ・言語変更など追加設定にアクセス。
+      alignment: 開始
+      prefferedSide: 下
+  - element: '#navbar-collections_tour'
+    popover:
+      title: コレクションメニュー
+      description: コレクションメニューでクリップ・ボード・タブのコレクションを切り替え。プロジェクトやカテゴリごとに整理・カスタマイズ可能。
+      alignment: 中央
+      prefferedSide: 下
+  - element: '#navbar-toggle-history-split'
+    popover:
+      title: 履歴ウィンドウ切り替え
+      description: このアイコンでクリップボード履歴を別ウィンドウで開閉。履歴を独立して管理可能。
+      alignment: 中央
+      preferredSide: 下
+  - element: '#navbar-search_tour'
+    popover:
+      title: グローバル検索
+      description: グローバル検索でアクティブコレクション内のクリップ・ボード・メニュー項目を素早く検索。キーワード入力で絞り込み、<b>ダブルクリック</b>で直接コピー。
+      alignment: 中央
+      prefferedSide: 下
+  - element: '#navbar-pinned_tour'
+    popover:
+      title: ピン留めボード切り替え
+      description: このアイコンでピン留めボードの表示/非表示を切り替え。重要な内容に集中できます。
+      alignment: 終端
+      prefferedSide: 下
+  - element: '#navbar-help_tour'
+    popover:
+      title: ヘルプメニュー
+      description: ヘルプメニューからガイドツアーやUI機能紹介に素早くアクセス。段階的な案内やデモでPasteBarの機能やUIを理解できます。
+      alignment: 終端
+      prefferedSide: 下
+  - element: '#navbar-close-window_tour'
+    popover:
+      title: メインウィンドウを閉じる
+      description: このアイコンでPasteBarのメインウィンドウを閉じ、タスクバーやメニューバーから機能を継続利用可能。メインウィンドウはメニューから再表示できます。
+      alignment: 終端
+      prefferedSide: 下
+
+SETTINGS_TOUR:
+  - element: '#app-settings-history_tour'
+    popover:
+      title: クリップボード履歴設定
+      description: 履歴の自動更新・自動スター・リンクプレビュー・ストップワード・プログラミング言語自動検出などを有効/無効にして履歴管理をカスタマイズできます。
+      alignment: 開始
+      prefferedSide: 右
+  - element: '#app-settings-collections_tour'
+    popover:
+      title: コレクション設定管理
+      description: コレクションの追加・編集・切替でワークフローに合わせてクリップ・ボード・タブを整理。関連コンテンツを効率的に管理。
+      alignment: 開始
+      prefferedSide: 右
+  - element: '#app-settings-preferences_tour'
+    popover:
+      title: ユーザー設定
+      description: フォントサイズ・カラーテーマ・言語切替・自動起動・パネルレイアウト・ナビバーコレクション名・クリップノートポップアップなどを調整。
+      alignment: 開始
+      prefferedSide: 右
+  - element: '#app-settings-security_tour'
+    popover:
+      title: セキュリティ設定
+      description: データ保護のためロック画面パスコードや復旧用パスワードを設定。ロック画面で履歴キャプチャ制御や自動ロックも調整可能。
+      alignment: 開始
+      prefferedSide: 右
+  - element: '#app-settings-back_tour'
+    popover:
+      title: メイン画面に戻る
+      description: 設定画面からメインアプリ画面に戻ります。
+      alignment: 開始
+      prefferedSide: 右

--- a/ja/updater.yaml
+++ b/ja/updater.yaml
@@ -1,0 +1,30 @@
+Check for Update: アップデートを確認
+Checking for Update...: アップデートを確認中...
+Confirm Restart: 再起動の確認
+Confirm Update: アップデートの確認
+Download Completed: ダウンロード完了
+Download Completed Quit and Manually Install: ダウンロードしたアップデートファイルは自動的に開きます。アップデートを完了するには、まずPasteBarを終了し、手動で最新版をインストールしてください。インストール完了後、更新されたPasteBarを起動してください。
+Download Update: アップデートをダウンロード
+Downloading...: ダウンロード中...
+General Update Error: アップデート処理中にエラーが発生しました。後でもう一度お試しください。問題が解決しない場合は手動でアップデートをダウンロード・インストールしてください。
+Install Update: アップデートをインストール
+Installing Update: アップデートをインストール中
+No Update Available: 利用可能なアップデートはありません
+Permission Denied Message: 権限不足のため古いアプリケーションファイルを置き換えられませんでした。管理者権限のあるユーザーで手動アップデートを行ってください。
+Quit PasteBar: PasteBarを終了
+Release date {{date}}: リリース日 {{date}}
+Remind Me Later: 後で通知
+Restart: 再起動
+Restart Required: 再起動が必要です
+Restart to Finish: 完了するには再起動
+Restart to Update: アップデートのためPasteBarを再起動
+Skip Download: ダウンロードをスキップ
+Skip This Version: このバージョンをスキップ
+Try Install Again: もう一度インストールを試す
+Update Available: アップデートがあります
+Update Error: アップデートエラー
+Update Install Error: アップデートインストールエラー
+'Update: Permission Denied': 'アップデート: 権限拒否'
+Upgrade removes Pro features: アップグレードでPro機能が削除されます
+Version {{newVersion}} is available: バージョン{{newVersion}}が利用可能です
+View Changes: 変更内容を見る

--- a/services/translations/translations.yaml
+++ b/services/translations/translations.yaml
@@ -96,3 +96,14 @@ tr:
   open_pastebar: PasteBar'ı Aç
   unlock_pastebar: PasteBar'ı Kilit Aç
   quit: Çıkış
+
+ja:
+  add_first_item_here: 最初のアイテムをここに追加
+  disable_history_capture: 履歴の監視を無効にする
+  enable_history_capture: 履歴の監視を有効にする
+  clipboard_image_size: クリップボードの画像サイズ
+  history_capture_is_disabled: クリップボードの履歴監視は無効になってます
+  recent_history: 最近の履歴
+  open_pastebar: PasteBar を開く
+  unlock_pastebar: PasteBar をアンロックする
+  quit: 終了する


### PR DESCRIPTION
Added multiple Japanese translation files for various application modules, including backup/restore, calendar, collections, common UI, context menus, dashboard, help, history, menus, navbar, pinned, settings, templates, tours, and updater. These files provide localized strings to support Japanese language in the application.
This pull request introduces extensive updates to Japanese localization files, adding new translations for various features and improving the application's usability for Japanese-speaking users. The changes span multiple files, focusing on backup and restore functionality, calendar terms, collection management, common phrases, context menus, and onboarding messages.

### Backup and Restore Functionality
* Added translations for backup-related actions and messages, such as creating, restoring, and deleting backups, as well as error handling and user prompts (`ja/backuprestore.yaml`).

### Calendar Terms
* Introduced translations for calendar-related terms, including days, weeks, months, and years, along with qualifiers like "recent" and "older than" (`ja/calendar.yaml`).

### Collection Management
* Added translations for managing collections, including creating, deleting, protecting with PINs, and navigating between collections (`ja/collections.yaml`).

### Common Phrases and Onboarding
* Expanded the common phrases library with translations for frequently used actions (e.g., copy, paste, save) and error messages. Also added onboarding messages for new users (`ja/common.yaml`, `ja/common2.yaml`). [[1]](diffhunk://#diff-889ab2dc4564374418b15ba0569cc59ce6b35f1df9035ee89b01170a58b25146R1-R359) [[2]](diffhunk://#diff-012d5d794f1410a9ad0edb7e8abc6796f7ae2d326b57a3d5dde7d6c4afd486abR1-R4)

### Context Menus
* Updated context menu translations to include actions like adding items, editing, organizing, and managing boards and clips (`ja/contextMenus.yaml`).
### Backup and Restore
* Added translations for backup creation, restoration, and error messages, such as "Backup Now," "Restore Data," and "Failed to create backup" (`ja/backuprestore.yaml`, [ja/backuprestore.yamlR1-R46](diffhunk://#diff-193bde7e7ab77a29022f3869a9fb25184b4494b9e6dc717cb0e26f51ccca34eaR1-R46)).

### Calendar and Time
* Added translations for time-related terms such as "Day," "Month," "Year," and phrases like "Older then" and "recent" (`ja/calendar.yaml`, [ja/calendar.yamlR1-R22](diffhunk://#diff-c193611ba6f114bde767a31b9ce193d352ded43498a82e690574dbcd145638e5R1-R22)).

### Collections Management
* Added translations for managing collections, including "Add Collection," "Delete Collection," and "Protected Collection" (`ja/collections.yaml`, [ja/collections.yamlR1-R26](diffhunk://#diff-72b2de082b840413860627e2f31daf746564615f9b5abfac27b9dd8a7d17a101R1-R26)).

### Common UI Elements
* Added a wide range of translations for common interface elements, such as "Clipboard History," "Confirm Delete," and "Upgrade to Pro" (`ja/common.yaml`, [ja/common.yamlR1-R359](diffhunk://#diff-889ab2dc4564374418b15ba0569cc59ce6b35f1df9035ee89b01170a58b25146R1-R359)).
* Introduced onboarding messages like "Welcome to PasteBar" and "Start using PasteBar" (`ja/common2.yaml`, [ja/common2.yamlR1-R4](diffhunk://#diff-012d5d794f1410a9ad0edb7e8abc6796f7ae2d326b57a3d5dde7d6c4afd486abR1-R4)).

### Context Menus
* Added translations for context menu actions, including "Add Clip," "Edit Board," and "UnPin Clip" (`ja/contextMenus.yaml`, [ja/contextMenus.yamlR1-R109](diffhunk://#diff-1631fc24836d83b3f88419f926a77ed85ed89b1e4f50baea0bd87931886d6f38R1-R109)).