### PR TITLE
Add nl-NL (Dutch) translations

### DIFF
--- a/nl-NL/backuprestore.yaml
+++ b/nl-NL/backuprestore.yaml
@@ -1,0 +1,46 @@
+Auto Backup on Restore: Automatische back-up bij herstellen
+Available Backups: Beschikbare back-ups
+Backup Files: Back-upbestanden
+Backup Now: Nu back-up maken
+Backup and Restore: Back-up en herstellen
+Backup created successfully: Back-up succesvol aangemaakt
+Backup deleted successfully: Back-up succesvol verwijderd
+Backup on Restore: Back-up bij herstellen
+Browse: Bladeren
+Create Backup: Back-up maken
+Create a backup of your data?: Wilt u een back-up van uw gegevens maken?
+Created: Aangemaakt
+Creating backup...: Back-up wordt gemaakt...
+Delete: Verwijderen
+Delete this backup? This action cannot be undone.: Deze back-up verwijderen? Deze actie kan niet ongedaan worden gemaakt.
+Failed to create backup: Back-up maken mislukt
+Failed to delete backup: Back-up verwijderen mislukt
+Failed to load backup list: Back-uplijst laden mislukt
+Failed to open backup folder: Back-upmap openen mislukt
+Failed to restore backup: Back-up herstellen mislukt
+Failed to select backup file: Selecteren van back-upbestand mislukt
+Include images in backup: Afbeeldingen opnemen in back-up
+Invalid backup file: Ongeldig back-upbestand
+Loading backups...: Back-ups laden...
+Move to another location?: Naar een andere locatie verplaatsen?
+No backups found: Geen back-ups gevonden
+Restore: Herstellen
+Restore Data: Gegevens herstellen
+Restore completed. The application will restart.: Herstellen voltooid. De applicatie wordt opnieuw gestart.
+Restore from "{{filename}}"? This will replace all current data.: Herstellen vanaf {{filename}}? Dit vervangt alle huidige gegevens.
+Restore from File...: Herstellen vanuit bestand...
+Restore from {{filename}}? This will replace all current data.: Herstellen vanaf {{filename}}? Dit vervangt alle huidige gegevens.
+Restored from {{filename}}: Hersteld vanaf {{filename}}
+Restoring a backup will automatically restart the application.: Het herstellen van een back-up start de applicatie automatisch opnieuw.
+Restoring backup...: Back-up herstellen...
+Restoring...: Bezig met herstellen...
+Select backup file: Selecteer back-upbestand
+Size: Grootte
+The selected file is not a valid PasteBar backup: Het geselecteerde bestand is geen geldige PasteBar-back-up
+This action cannot be undone. All current data will be replaced with the backup data.: Deze actie kan niet ongedaan worden gemaakt. Alle huidige gegevens worden vervangen door de back-upgegevens.
+This will create a backup file containing your database: Dit maakt een back-upbestand met uw database
+This will replace all current data. Are you sure?: Dit vervangt alle huidige gegevens. Weet u het zeker?
+Total backup space {{size}}: Totale back-upruimte: {{size}}
+and images: en afbeeldingen
+selected file: geselecteerd bestand
+will be permanently deleted.: wordt permanent verwijderd.

--- a/nl-NL/calendar.yaml
+++ b/nl-NL/calendar.yaml
@@ -1,0 +1,22 @@
+Day: Dag
+Days: Dagen
+Days2: Dagen
+Days3: Dagen
+Month: Maand
+Months: Maanden
+Months2: Maanden
+Older then: Ouder dan
+Hour: Uur
+Hours: Uren
+Week: Week
+Weeks: Weken
+Week2: Week
+Year: Jaar
+Years: Jaren
+Years2: Jaren
+and older: en ouder
+last: laatste
+last2: laatste
+last3: laatste
+older then: ouder dan
+recent: recent

--- a/nl-NL/collections.yaml
+++ b/nl-NL/collections.yaml
@@ -1,0 +1,26 @@
+Add Collection: Collectie toevoegen
+Add a description for your collection: Voeg een beschrijving toe voor uw collectie
+Add default menu, tab and board: Standaardmenu, tabblad en bord toevoegen
+Are you sure you want to delete this collection?: Weet u zeker dat u deze collectie wilt verwijderen?
+Choose which collections require PIN entry for access.: Kies welke collecties een pincode vereisen voor toegang.
+Collection Options: Collectie-opties
+Collection Title: Collectietitel
+Collections: Collecties
+Current Collection: Huidige collectie
+Delete Collection: Collectie verwijderen
+Delete all menu items within this collection: Alle menu-items binnen deze collectie verwijderen
+? Deleting the collection will remove it permanently. You can also choose to delete all menu and clips items within the collection by checking the box below.
+: Door de collectie te verwijderen wordt deze permanent verwijderd. U kunt er ook voor kiezen om alle menu- en clipitems binnen de collectie te verwijderen door het onderstaande vakje aan te vinken.
+Description: Beschrijving
+Display full name of selected collection on the navigation bar: Volledige naam van de geselecteerde collectie weergeven in de navigatiebalk
+Enter collection title: Voer een collectietitel in
+Manage Collections: Collecties beheren
+Pin Protected Collections: Met pincode beveiligde collecties
+Protect Collections with PIN: Collecties beveiligen met pincode
+Protected Collection: Beveiligde collectie
+Select Collections: Collecties selecteren
+Select protected collections: Beveiligde collecties selecteren
+Show collection name on the navbar: Collectienaam tonen in de navigatiebalk
+Switch collections: Wissel van collectie
+You can add the selected text to your clips or menu. Please select the option below.: U kunt de geselecteerde tekst toevoegen aan uw clips of menu. Selecteer hieronder de gewenste optie.
+You need to select a different collection before deleting the current one.: U moet eerst een andere collectie selecteren voordat u de huidige verwijdert.

--- a/nl-NL/common.yaml
+++ b/nl-NL/common.yaml
@@ -1,0 +1,359 @@
+' No':  No
+' This permission ensures PasteBar can access the clipboard and perform copy and paste operations across applications.':  This permission ensures PasteBar can access the clipboard and perform copy and paste operations across applications.
+About PasteBar: About PasteBar
+Action Menu: Action Menu
+? Add <b>{{Clipboard}}</b> field to template. This allows you to copy text to the clipboard, and it will be inserted into the template
+: Add <b>{{Clipboard}}</b> field to template. This allows you to copy text to the clipboard, and it will be inserted into the template
+Add Clip: Add Clip
+Add First Option: Add First Option
+Add Link Card: Add Link Card
+Add Menu: Add Menu
+Add Option: Add Option
+Add PasteBar to Accessibility: Add PasteBar to Accessibility
+Add To Player: Add To Player
+Add to: Add to
+Add to Clips: Add to Clip
+Add to Clips or Menu: Add to Clips or Menu
+Add to Menu: Add to Menu
+Add to clip or menu: Add to clip or menu
+Add to template fields: Add to template fields
+Added: Added
+Adding this file to the player is not recommended unless you trust the source.: Adding this file to the player is not recommended unless you trust the source.
+Allow PasteBar to Copy and Paste from Clipboard: Allow PasteBar to Copy and Paste from Clipboard
+Are you sure you want to delete?: Are you sure you want to delete?
+Are you sure?: Are you sure?
+Attach History Window: Attach History Window
+Back: Terug
+Build on {{buildDate}}: Build on {{buildDate}}
+Cancel: Annuleren
+Cancel Reset: Cancel Reset
+Check: Check
+Check / Done: Check / Done
+Check and Close: Check and Close
+Check and Done: Check and Done
+Clear History: Clear History
+Clear Tracks: Clear Tracks
+Clear found results and filters: Clear found results and filters
+Click to Confirm: Click to Confirm
+Clip: Clip
+Clip Boards: Clip Boards
+Clipboard: Clipboard
+Clipboard History: Clipboard History
+Clipboard History Only: Clipboard History Only
+Clipboard History Settings: Clipboard History Settings
+Close: Sluiten
+Close Edit: Close Edit
+Close Expand Edit: Close Expand Edit
+Close Find: Close Find
+Close History Window: Close History Window
+Close modal and continue in browser: Close modal and continue in browser
+Confirm: Bevestigen
+Confirm  action: Confirm  action
+Confirm Delete: Confirm Delete
+Confirm Email: Confirm Email
+Confirm Passcode: Confirm Passcode
+Confirm Password: Confirm Password
+Confirm Remove: Confirm Remove
+Confirm Your Passcode: Confirm Your Passcode
+Confirm Passcode Reset: Confirm Passcode Reset
+Confirm Password Reset: Confirm Password Reset
+Confirm Add To Protected Collections: Confirm add to protected collections
+Confirm Disable PIN Protection: Confirm disable PIN protection
+Confirm Remove From Protected Collections: Confirm remove from protected collections
+Confirm Enable PIN Protection: Confirm enable PIN protection
+Contact Form: Contact Form
+Copied: Copied
+Copy: Kopiëren
+Copy & Paste: Copy & Paste
+Copy and Paste: Copy and Paste
+'Copy of ': Copy of 
+Copy to Clipboard: Copy to Clipboard
+Create: Aanmaken
+Created: Created
+Delay Next: Delay Next
+Delete: Verwijderen
+Deselect All: Deselect All
+Deselect pinned: Deselect pinned
+Digits Only Passcode: Digits Only Passcode
+Disabled: Uitgeschakeld
+Done: Done
+Done Adding: Done Adding
+Done Edit: Done Edit
+Done Reorder: Done Reorder
+Download mp3: Download mp3
+Drag: Drag
+Drag to Move: Drag to Move
+Drop To Add: Drop To Add
+Drop Zone: Drop Zone
+Edit: Bewerken
+Edit Label: Edit Label
+'Email: {{email}}': 'Email: {{email}}
+Emoji: Emoji
+Empty: Empty
+Empty Select: Empty Select
+Enable / Disable: Enable / Disable
+Enable PasteBar in Accessibility Settings: Enable PasteBar in Accessibility Settings
+Enabled: Ingeschakeld
+Enter Current Passcode: Enter Current Passcode
+Enter Digits Only Passcode: Enter Digits Only Passcode
+Enter Email: Enter Email
+Enter PIN to Access Protected Collection: Enter PIN to Access Protected Collection
+Enter Passcode: Enter Passcode
+Enter Password: Enter Password
+Enter Recovery Password: Enter Recovery Password
+Enter passcode or password to unlock: Enter passcode or password to unlock
+Error: Fout
+Errors: 
+  Error loading link: Error loading link
+  Cant save to file: Cant save to file
+  Something went wrong! {{err}} Please try again.: Something went wrong! {{err}} Please try again.
+Expand Edit: Expand Edit
+Expires on {{proExpiresOn}}: Expires on {{proExpiresOn}}
+? Field <b>{{Clipboard}}</b> has been found in the template. This allows you to copy text to the clipboard, and it will be inserted into the template
+: Field <b>{{Clipboard}}</b> has been found in the template. This allows you to copy text to the clipboard, and it will be inserted into the template
+Field is not found in the template: Field is not found in the template
+Find Clip: Find Clip
+Find History: Find History
+Found in template but missing from fields definition: Found in template but missing from fields definition
+Got it: Got it
+Hide Muli Select: Hide Muli Select
+Hide Pinned Board: Hide Pinned Board
+History: History
+Image: Image
+Image Scale {{ImageScale}}x: Image Scale {{ImageScale}}x
+Image size: Image size
+Image size in pixels: Image size in pixels
+In View: In View
+In View Edit: In View Edit
+Inactive: Inactive
+Large View: Large View
+Large View Edit: Large View Edit
+Later: Later
+Light: Light
+Lines Wrap: Lines Wrap
+Make Active: Make Active
+Make Disabled: Make Disabled
+Make Enabled: Make Enabled
+Make Inactive: Make Inactive
+Manage: Manage
+Maximum height: Maximum height
+Maximum length: Maximum
+Maximum width: Maximum width
+Menu: Menu
+Minimum length: Minimum
+Move Down: Move Down
+Move Up: Move Up
+Multi Select: Multi Select
+'Name: {{name}}': 'Name: {{name}}
+Next Delay: Next Delay
+Next Track: Next Track
+No: Nee
+No Key Press: No Key Press
+No Wrap: No Wrap
+Not Now: Not Now
+Not found in the template: Not found in the template
+Nothing found: Nothing found
+Number of lines: Number of lines
+Ok, but later: Ok, but later
+Open: Openen
+Open Accessibility: Open Accessibility
+Open History Window: Open History Window
+Open Window: Open Window
+Open contact form in browser: Open contact form in browser
+Open payment in browser: Open payment in browser
+Options: Options
+Password: Password
+Paste Delay: Paste Delay
+Paste Menu: Paste Menu
+Paste in {{pastingCountDown}}...: Paste in {{pastingCountDown}}...
+PasteBar: PasteBar
+PasteBar Application Error: PasteBar Application Error
+PasteBar History: PasteBar History
+PasteBar application now can access the clipboard and perform copy and paste operations across applications.: PasteBar application now can access the clipboard and perform copy and paste operations across applications.
+PasteBar was successfuly added to Accessibility settings: PasteBar was successfuly added to Accessibility settings
+Pasted: Pasted
+Path: Path
+Pause: Pause
+Pause Playing: Pause Playing
+? 'Permission Check Failed: PasteBar has not been successfully added to Accessibility settings. Please grant the required permissions and click Done again.
+: Permission Check Failed: PasteBar has not been successfully added to Accessibility settings. Please grant the required permissions and click Done again.
+Pin Selected: Pin Selected
+Pinned: Pinned
+Play: Play
+Please add PasteBar to the list of apps in: Please add PasteBar to the list of apps in
+Please confirm your action!: Please confirm your action!
+Press: Press
+Press ESC key to close: Press ESC key to close
+Previous Track: Previous Track
+Pro: Pro
+Quit: Quit
+Rebuild Menu: Rebuild Menu
+Recent History: Recent History
+Recovery Password: Recovery Password
+Remove: Verwijderen
+Remove Link Card: Remove Link Card
+Remove Selected Star: Remove Selected Star
+Remove all fields from template: Remove all fields from template
+Remove all tracks: Remove all tracks
+Remove current track: Remove current track
+Remove from Player: Remove from Player
+Remove from template: Remove from template
+Rename: Rename
+Renew: Renew
+Reorder pinned: Reorder pinned
+Repeat 1: Repeat 1
+Repeat all: Repeat all
+Repeat off: Repeat off
+Report and Try Again: Report and Try Again
+Reset: Reset
+Reset Passcode: Reset Passcode
+Reset Password: Reset Password
+Reset with Passcode: Reset with Passcode
+Restart: Restart
+Reverse Order: Reverse Order
+Run and Copy Response: Run and Copy Response
+Run and Paste Response: Run and Paste Response
+Running: Running
+Save: Opslaan
+Save It!: Save It!
+Saved: Saved
+Scroll to Top: Scroll to Top
+Second: Second
+Seconds: Seconds
+'Security Alert: MP3 Verification Failed': 'Security Alert: MP3 Verification Failed
+Select: Select
+Select Default Option: Select Default Option
+Select Language: Select Language
+Select default: Select default
+Select is empty: Select is empty
+Select option: Select option
+Select pinned: Select pinned
+Separate History Window: Separate History Window
+Sequence Copy: Sequence Copy
+Sequence Copy Paste: Sequence Copy Paste
+Sequence Delay Next: Sequence Delay Next
+Sequence Next Delay: Sequence Next Delay
+Sequence Paste: Sequence Paste
+Sequence Reverse Order: Sequence Reverse Order
+Set: Set
+Set Password: Set Password
+Show Large View: Show Large View
+Show all: Show all
+Size: Size
+Source: Source
+Star: Star
+Star Selected: Star Selected
+Stay here: Stay here
+Stay in touch: Stay in touch
+Success!: Success!
+Swap Panels Layout: Swap Panels Layout
+System Settings -> Privacy & Security -> Accessibility: System Settings -> Privacy & Security -> Accessibility
+Thank you for reporting the error.: Thank you for reporting the error.
+Thank you for using Pro: Thank you for using Pro
+Thank you!: Thank you!
+This permission ensures PasteBar can access the clipboard and perform copy and paste operations across applications.: This permission ensures PasteBar can access the clipboard and perform copy and paste operations across applications.
+Too long: Too long
+Too short: Too short
+Toolbar: 
+  Blank Text Formatting: Blank Text Formatting
+  Bold Formatting: Bold Formatting
+  Bold Text Formatting: Bold Text Formatting
+  Copy and Paste Formatting: Copy and Paste Formatting
+  Header Formatting: Header Formatting
+  Hightlight Text Formatting: Hightlight Text Formatting
+  Italic Formatting: Italic Formatting
+  Masked Text Formatting: Masked Text Formatting
+  Remove Text Formatting: Remove Text Formatting
+Trust and Play: Trust and Play
+Type: 
+  App: App
+  Auto Fill: Auto Fill
+  AutoFill: AutoFill
+  Clip: Clip
+  Code: Code
+  Code Snippet: Code Snippet
+  Command: Command
+  Email: Email
+  Emoji: Emoji
+  Empty: Empty
+  Error: Fout
+  File: File
+  File, Path or App: File, Path or App
+  Form Auto Fill: Form Auto Fill
+  Image: Image
+  Label: Label
+  Link: Link
+  Link or Email: Link or Email
+  Menu: Menu
+  Mp3: mp3
+  Path: Path
+  Plain Text: Plain Text
+  Request: Request
+  Run Auto Fill: Run Auto Fill
+  Scraper: Scraper
+  Secret: Secret
+  Trim: Trim Spaces
+  Shell Command: Shell Command
+  Submenu: Submenu
+  Template: Template
+  Template Fill: Template Fill
+  Text: Text
+  Video: Video
+  Web Request (HTTP): Web Request (HTTP)
+  Web Scraper / Parser: Web Scraper / Parser
+TypeMenu: 
+  Clip Type: Clip Type
+  Code Snippet: Code Snippet
+  File, Path or App: File, Path or App
+  Form Auto Fill: Form Auto Fill
+  Image: Image
+  Link or Email: Link or Email
+  Link or File, Path or App: Link or File, Path or App
+  Plain Text: Plain Text
+  Run, Execute: Run, Execute
+  Select Language: Select Language
+  Shell Command: Shell Command
+  Template: Template
+  Template Fill: Template Fill
+  Text Template: Text Template
+  Web Request (HTTP): Web Request (HTTP)
+  Web Scraper / Parser: Web Scraper / Parser
+UnPin All: UnPin All
+UnPin Selected: UnPin Selected
+Unlock Application Screen: Unlock Application Screen
+Unlock Pro features: Unlock Pro features
+Unlock Screen: Unlock Screen
+Unlock all features: Unlock all features
+Unsaved label: Unsaved label
+Update Error: Update Error
+Update history list: Update history list
+Updated: Updated
+Upgrade to Pro: Upgrade to Pro
+Use Passcode: Use Passcode
+Use Password: Use Password
+Using <b>{{Clipboard}}</b> field, allows you to copy text to the clipboard, and it will be inserted into the template: Using <b>{{Clipboard}}</b> field, allows you to copy text to the clipboard, and it will be inserted into the template
+Verify: Verify
+Verify Current Password: Verify Current Password
+Verify Recovery Password: Verify Recovery Password
+Version: Version
+View: View
+View Edit: View Edit
+Views: 
+  Paste Menu: Paste Menu
+We apologize but you found a bug. Please report this issue to us and try again: We apologize but you found a bug. Please report this issue to us and try again
+? We couldn't confirm this file's safety. Failed ID3 tag verification and integrity check. MP3 files can potentially contain malware. Please be cautious.
+: We couldn't confirm this file's safety. Failed ID3 tag verification and integrity check. MP3 files can potentially contain malware. Please be cautious.
+Yes: Ja
+Yes, activate: Yes, activate
+chars: chars
+contact us.: contact us.
+found: found
+if this error persists, try to restart the application or: if this error persists, try to restart the application or
+lines: lines
+menu items in: menu items in
+minutes: minutes
+only: only
+second: second
+seconds: seconds
+show less: show less
+www.site: www.pastebar.app

--- a/nl-NL/common2.yaml
+++ b/nl-NL/common2.yaml
@@ -1,0 +1,4 @@
+Please select your preferred language: Please select your preferred language
+Start using PasteBar: Start using PasteBar
+Submenus will move up one level after delete: Submenus will move up one level after delete
+Welcome to PasteBar: Welcome to PasteBar

--- a/nl-NL/contextMenus.yaml
+++ b/nl-NL/contextMenus.yaml
@@ -1,0 +1,109 @@
+Activate: Activate
+Add Board: Add Board
+Add Clip: Add Clip
+Add First Tab: Add First Tab
+Add Item: Add Item
+Add Link Card: Add Link Card
+Add New: Add New
+Add New After: Add New After
+Add New Item: Add New Item
+Add Tab: Add Tab
+Add to: Add to
+Add to Menu: Add to Menu
+AddTo: 
+  Add to Exclude and Delete: Add to Exclude and Delete
+  Add to Filter by Source: Add to Filter by Source
+  Add to Ignore: Add to Ignore
+  Clip on Board: Clip on Board
+  Paste Menu: Paste Menu
+After: After
+After Item: After Item
+Board Icon: Board Icon
+Clip Icon: Clip Icon
+Close: Sluiten
+Close Edit: Close Edit
+Close Rename: Close Rename
+Close View: Close View
+Collapse View: Collapse View
+Copy & Paste: Copy & Paste
+Copy To: Copy To
+CopyTo: 
+  Board: Board
+  Tab: Tab
+Custom Icon: Custom Icon
+Dashboard: Dashboard
+Delete Board: Delete Board
+Delete Clip: Delete Clip
+Deselect: Deselect
+Detected Language: Detected Language
+Down: Down
+Duplicate: Dupliceren
+Edit Board: Edit Board
+Edit Clip: Edit Clip
+Edit Label: Edit Label
+Edit Tabs: Edit Tabs
+Edit Value: Edit Value
+End: End
+Expand View: Expand View
+Hide: Hide
+Hide Details: Hide Details
+Hide Subtitle: Hide Subtitle
+Icon Type: Icon Type
+Icon Visibility: Icon Visibility
+Large View: Large View
+Link To Clip: Link To Clip
+Locate Clip: Locate Clip
+Locate Menu: Locate Menu
+Make Disabled: Make Disabled
+Make Enabled: Make Enabled
+Make Inactive: Make Inactive
+Manage: Manage
+Mask Secret: Mask Secret
+Menu: Menu
+Menu is Not Active: Menu is Not Active
+Move Board To: Move Board To
+Move To: Move To
+MoveTo: 
+  Board: Board
+  Tab: Tab
+Note Icon: Note Icon
+Note Icon Settings: Note Icon Settings
+Note Icon Types Book: Book
+Note Icon Types Contact: Contact
+Note Icon Types File: File
+Note Icon Types Message: Message
+Note Icon Types Notebook: Notebook
+Open: Openen
+Open Link in Browser: Open Link in Browser
+Organize: Organize
+Organize Layout: Organize Layout
+Paste Delay: Paste Delay
+Paste Menu: Paste Menu
+Pin: Pin
+Position: Position
+RESET: RESET
+Remove Link Card: Remove Link Card
+Remove Star: Remove Star
+Rename: Rename
+Save as File: Save as File
+Save as Image File: Save as Image File
+Save as Mp3: Save as Mp3
+Save as Mp3 File: Save as Mp3 File
+Save as Text File: Save as Text File
+Select: Select
+Select Icon: Select Icon
+Separator: Separator
+Show: Show
+Show Large View: Show Large View
+Show Note Icon: Show Note Icon
+Show Subtitle: Show Subtitle
+Star: Star
+Start: Start
+Submenu: Submenu
+UnPin: UnPin
+UnPin Clip: UnPin Clip
+Unmask Secret: Unmask Secret
+Up: Up
+Use Global Setting: Use Global Setting
+View: View
+not a code: not a code

--- a/nl-NL/dashboard.yaml
+++ b/nl-NL/dashboard.yaml
@@ -1,0 +1,269 @@
+API Key: API Key
+Add: Toevoegen
+Add Auth: Add Auth
+Add Clipboard Value: Add Clipboard Value
+Add Custom: Add Custom
+Add Custom Field: Add Custom Field
+Add Delay Time: Add Delay Time
+Add First Board: Add First Board
+Add Form Field: Add Form Field
+Add Header: Add Header
+Add Key Press: Add Key Press
+Add Key Press After Paste: Add Key Press After Paste
+Add Link Card: Add Link Card
+Add Open URL: Add Open URL
+Add Output Template: Add Output Template
+Add Regex Match Group Filter: Add Regex Match Group Filter
+Add Request Header: Add Request Header
+Add Response Filter: Add Response Filter
+Add Scraping Rule: Add Scraping Rule
+Add Section: Add Section
+Add Tab: Add Tab
+Add Template Field: Add Template Field
+Add a Tab: Add a Tab
+Add field {{name}} into the template: Add field {{name}} into the template
+Add image: Add image
+Add note: Add note
+Add to Board: Add to Board
+Add {{type}}: Add {{type}}
+All field labels must be unique to ensure they are correctly used within the template.: All field labels must be unique to ensure they are correctly used within the template.
+Are you sure you want to delete <strong>{{boardName}}</strong> board?: Are you sure you want to delete <strong>{{boardName}}</strong> board?
+Are you sure you want to delete <strong>{{tabName}}</strong> tab?: Are you sure you want to delete <strong>{{tabName}}</strong> tab?
+Are you sure you want to delete?: Are you sure you want to delete?
+Are you sure you want to remove image from the clip?: Are you sure you want to remove image from the clip?
+Auth: Auth
+Auto update is Off: Auto update is Off
+Basic Auth: Basic Auth
+Basic Password: Basic Password
+Basic Username: Basic Username
+Bearer Token: Bearer Token
+Board Layout Height: Board Layout Height
+Board Layout Split: Board Layout Split
+Board Menu: Board Menu
+Board is Not Empty: Board is Not Empty
+Boards: Boards
+Border Width: Border Width
+CSS Selector: CSS Selector
+Cancel: Annuleren
+Change Layout: Change Layout
+Change color: Change color
+Clear: Clear
+Clear All Fields: Clear All Fields
+Click To Add: Click To Add
+Clip Menu: Clip Menu
+Clip Options: Clip Options
+Clipboard: Clipboard
+Clips: 
+  App: App
+  Clip Menu: Clip Menu
+  Clips: Clips
+  Link: Link
+Close Edit: Close Edit
+Command: 
+  error: error
+  output: output
+Command error: Command error
+Common Fields: Common Fields
+Confirm Clear All Fields: Confirm Clear All Fields
+Confirm to remove Auth: Confirm to remove Auth
+Confirm to remove filters: Confirm to remove filters
+Confirm to remove headers: Confirm to remove headers
+Copy Clip: Copy Clip
+Create Board: Create Board
+Create Tab: Create Tab
+Create tab: Create tab
+Dashboard: Dashboard
+Delay: Delay
+Delete Board: Delete Board
+Delete Clip: Delete Clip
+Delete Tab: Delete Tab
+Delete board: Delete board
+Delete field: Delete field
+Delete tab: Delete tab
+Detect Template Fields: Detect Template Fields
+Detect for Template Fields: Detect for Template Fields
+Disabled field {{name}} has been found in the template: Disabled field {{name}} has been found in the template
+Done Create Clip: Done Create Clip
+Done Edit: Done Edit
+Done Edit Tabs: Done Edit Tabs
+Done Organize: Done Organize
+Drag & Drop Path: Drag & Drop Path
+Drop To Add: Drop To Add
+Drop image file here, or use a separate window for drag and drop.: Drop image file here, or use a separate window for drag and drop.
+Drop to Pin: Drop to Pin
+Edit Note: Edit Note
+Edit Template: Edit Template
+Edit subtitle: Edit subtitle
+Edit tab name: Edit tab name
+Enable / Disable: Enable / Disable
+Enable / Disable URL Open: Enable / Disable URL Open
+Enter Label: Enter Label
+Enter URL: Enter URL
+Enter board subtitle or description: Enter board subtitle or description
+Enter board title: Enter board title
+Enter clip name: Enter clip name
+Enter clip note: Enter clip note
+Enter code: Enter code
+Enter credit card number: Enter credit card number
+Enter default value: Enter default value
+Enter field value: Enter field value
+Enter full path to file, folder or application: Enter full path to file, folder or application
+Enter regex for output filer: Enter regex for output filer
+Enter request url: Enter request url
+Enter secret value: Enter secret value
+Enter section label: Enter section label
+Enter select option: Enter select option
+Enter tab name: Enter tab name
+Enter template or drag from history: Enter template or drag from history
+Enter template value: Enter template value
+Enter value or drag from history: Enter value or drag from history
+Enter web link or email: Enter web link or email
+Errors: 
+  No fields found in the template.: No fields found in the template.
+  Please fix output template or confirm to save as is.: Please fix output template or confirm to save as is.
+  Please fix template fields or confirm to save as is.: Please fix template fields or confirm to save as is.
+  Please fix the problem or confirm to save as is.: Please fix the problem or confirm to save as is.
+  Please verify your link for any errors, or confirm to save as is.: Please verify your link for any errors, or confirm to save as is.
+  Please verify your path for any errors, or confirm to save as is.: Please verify your path for any errors, or confirm to save as is.
+  Your command runs with errors, confirm you want to save as is.: Your command runs with errors, confirm you want to save as is.
+  Your request runs with errors, confirm you want to save as is.: Your request runs with errors, confirm you want to save as is.
+FILTERED_TYPES: 
+  Dot Path: Dot Path
+  JSON Path: JSON Path
+  RegEx: RegEx
+  RegEx Replace: RegEx Replace
+  Remove Quotes: Remove Quotes
+Field: Field
+Field Options: Field Options
+Field {{name}} has been found in the template: Field {{name}} has been found in the template
+Fields Value: Fields Value
+File, folder or app path does not exist: File, folder or app path does not exist
+File, folder or app path is valid: File, folder or app path is valid
+File, folder or app path might not be valid: File, folder or app path might not be valid
+Fill Template: Fill Template
+Filter Type: Filter Type
+Filter's Value: Filter's Value
+Find in Clip: Find in Clip
+Find in clip: Find in clip
+Find in history: Find in history
+Flex Layout: Flex Layout
+Form Fields: Form Fields
+General Fields: General Fields
+Grid Layout: Grid Layout
+HTML: HTML
+Headers: Headers
+Hide Label: Hide Label
+History capture is off: History capture is off
+Key Press: Key Press
+Key Press After: Key Press After
+Key Press After Paste: Key Press After Paste
+'Key Press After Paste: {{keyPress}}': 'Key Press After Paste: {{keyPress}}
+Label Left: Label Left
+Label Top: Label Top
+Label on Left: Label on Left
+Labels: Labels
+Last run: Last run
+Last update: Last update
+Layout Max Width: Layout Max Width
+Mask to hide clipboard value in preview: Mask to hide clipboard value in preview
+Move Clip: Move Clip
+Moved Clips Panel: Moved Clips Panel
+Name: Naam
+New Board: New Board
+New Clip: New Clip
+No Boards: No Boards
+No Clipboard History: No Clipboard History
+No Tabs or Boards: No Tabs or Boards
+Number of columns: Number of columns
+Open: Openen
+Open URL Disable / Enable: Open URL Disable / Enable
+Output Template: Output Template
+Panel for moved or copied items from other tabs: Panel for moved or copied items from other tabs
+Please confirm to save as is.: Please confirm to save as is.
+Press: Press
+RETURN_POSITION_TYPES: 
+  First Only: First Only
+  Last Only: Last Only
+RULES_TYPES: 
+  CSS Selector: CSS Selector
+  RegEx Find: RegEx Find
+  RegEx Group Match: RegEx Group Match
+  RegEx Match: RegEx Match
+  RegEx Replace: RegEx Replace
+RegEx Find: RegEx Find
+RegEx Match: RegEx Match
+RegEx Match Group: RegEx Match Group
+RegEx Replace: RegEx Replace
+Regex Match Group Filter: Regex Match Group Filter
+Remove Open URL: Remove Open URL
+Remove headers: Remove headers
+Remove image: Remove image
+Rename: Rename
+Reset to Defaults: Reset to Defaults
+Response Filters: Response Filters
+Result: Result
+SEPARATOR_TYPES: 
+  Comma (,): Comma (,)
+  New Line (\n): New Line (\n)
+  Pipe (|): Pipe (|)
+  Semicolon (;): Semicolon (;)
+  Space (' '): Space (' ')
+  Tab (\t): Tab (\t)
+Save as Defaults: Save as Defaults
+Scan for Template Fields: Scan for Template Fields
+Select Color: Select Color
+Select Default Option: Select Default Option
+Select Option: Select Option
+Select Options: Select Options
+Show Label: Show Label
+Special Field: Special Field
+Subtitle: Subtitle
+Tab: Tab
+Tab is Not Empty: Tab is Not Empty
+Tabs Menu: Tabs Menu
+Template: Template
+Template Edit: Template Edit
+Template Fields: Template Fields
+Template should have⠀<b>{{output}}</b>⠀placeholder.: Template should have⠀<b>{{output}}</b>⠀placeholder.
+Test Request: Test Request
+Test Run: Test Run
+Text: Text
+This action cannot be undone.: This action cannot be undone.
+This field allows to insert text from clipboard: This field allows to insert text from clipboard
+Too long: Too long
+Too short: Too short
+Turn On auto update: Turn On auto update
+Turn on history capture: Turn on history capture
+Type: 
+  Command: Command
+  Request: Request
+  Scraper: Scraper
+URL: URL
+Unsaved name: Unsaved name
+Unsaved note: Unsaved note
+Unsaved subtitle: Unsaved subtitle
+Unsaved title: Unsaved title
+Update Link Card: Update Link Card
+Use double curly brackets for {{field name}}. Use {{clipboard}} to add current clipboard value.: Use double curly brackets for {{field name}}. Use {{clipboard}} to add current clipboard value.
+Value: Value
+Values: Values
+Vertical Split: Vertical Split
+We need to open a new window where you can drag & drop file, path or application.: We need to open a new window where you can drag & drop file, path or application.
+Web Link or Email might not be valid: Web Link or Email might not be valid
+Web or Email link is valid: Web or Email link is valid
+Website URL: Website URL
+Website URL is valid: Website URL is valid
+Website URL might not be valid: Website URL might not be valid
+Wrap output using {{output}} placeholder: Wrap output using {{output}} placeholder
+You have no rules added: You have no rules added
+You'll need to clear this board of all clips and subboards before it can be deleted.: You'll need to clear this board of all clips and subboards before it can be deleted.
+You'll need to clear this tab of all boards before it can be deleted.: You'll need to clear this tab of all boards before it can be deleted.
+filled template: filled template
+new clips: new clips
+template: template
+'{{count}} fields found in template but missing from fields definition._one': {{count}} fields found in template but missing from fields definition.
+'{{count}} fields found in template but missing from fields definition._other': {{count}} fields found in template but missing from fields definition.
+'{{count}} fields not found in the template._one': {{count}} fields not found in the template.
+'{{count}} fields not found in the template._other': {{count}} fields not found in the template.
+'{{type}} Field': {{type}} Field
+'{{type}} field': {{type}} field

--- a/nl-NL/help.yaml
+++ b/nl-NL/help.yaml
@@ -1,0 +1,88 @@
+Add Menu Item: Add Menu Item
+App Guided Tours: App Guided Tours
+Board Panel: Board Panel
+Board Panel Header: Board Panel Header
+Boards and Clips: Boards and Clips
+Boards and Clips Tour: Boards and Clips Tour
+Clipboard History: Clipboard History
+Clipboard History Item: Clipboard History Item
+Clipboard History Panel: Clipboard History Panel
+Clipboard History Settings: Clipboard History Settings
+Clipboard History Tour: Clipboard History Tour
+Close Main Window: Close Main Window
+Collections Menu: Collections Menu
+Congratulations! You have finished <strong>all the tours</strong> and now ready to make the most of PasteBar's features. Remember, all tours always available from the <strong>Help > App Guided Tours</strong> menu in the navbar.: Congratulations! You have finished <strong>all the tours</strong> and now ready to make the most of PasteBar's features. Remember, all tours always available from the <strong>Help > App Guided Tours</strong> menu in the navbar.
+Contact Us Form: Contact Us Form
+Create Dashboard Items: Create Dashboard Items
+Dashboard Panel: Dashboard Panel
+Dashboard Tabs: Dashboard Tabs
+Done: Done
+Feature Highlights: Feature Highlights
+Feel free to explore the app on your own. If you need help or want to access the tours later, you can always find them in the <strong>Help > App Guided Tours</strong> menu in the navigation bar.: Feel free to explore the app on your own. If you need help or want to access the tours later, you can always find them in the <strong>Help > App Guided Tours</strong> menu in the navigation bar.
+Find Menu Items: Find Menu Items
+Find and Filter History: Find and Filter History
+Global Search: Global Search
+Got It: Got It
+Great job! You have completed this tour. Ready to see more? Click <i>Skip</i> if you want to explore on your own. All tours always available from the <strong>Help > App Guided Tours</strong> menu in the navbar.: Great job! You have completed this tour. Ready to see more? Click <i>Skip</i> if you want to explore on your own. All tours always available from the <strong>Help > App Guided Tours</strong> menu in the navbar.
+Guided Tours Options: Guided Tours Options
+Help: Help
+Help Menu: Help Menu
+History Selected Items Menu: History Selected Items Menu
+History/Menu Navigation Tabs: History/Menu Navigation Tabs
+Later: Later
+Let's get started: Let's get started
+Manage Collections Settings: Manage Collections Settings
+Manage Paste Menu Panel: Manage Paste Menu Panel
+Mark All Completed: Mark All Completed
+Menu Item: Menu Item
+Menu Item Tree: Menu Item Tree
+Navigation Bar: Navigation Bar
+Navigation Bar Menu: Navigation Bar Menu
+Navigation Bar Tour: Navigation Bar Tour
+Next: Next
+Next Tour: Next Tour
+Paste Menu: Paste Menu
+Paste Menu Panel: Paste Menu Panel
+Paste Menu Tour: Paste Menu Tour
+Paste Menu View: Paste Menu View
+PasteBar Menu: PasteBar Menu
+PasteBar Settings: PasteBar Settings
+PasteBar Settings Tour: PasteBar Settings Tour
+PasteBar Tour: PasteBar Tour
+Previous: Previous
+Priority Support: Priority Support
+Reset All Tours: Reset All Tours
+Resizable Panel View: Resizable Panel View
+Return to the Main Screen: Return to the Main Screen
+Saved Clip Item: Saved Clip Item
+Security Settings: Security Settings
+Selected Items Paste Menu: Selected Items Paste Menu
+Skip: Skip
+Skip All Tours: Skip All Tours
+Skip Tour: Skip Tour
+Skip Update: Skip Update
+Start: Start
+Start Next Tour: Start Next Tour
+Start Tour: Start Tour
+Support and Feedback: Support and Feedback
+Tabs and Layout Menu: Tabs and Layout Menu
+Title on Popover: Title on Popover
+Toggle Inactive Menu Items: Toggle Inactive Menu Items
+Toggle Pinned Board: Toggle Pinned Board
+Toggle History Window: Toggle History Window
+Tour Completed: Tour Completed
+Tour Skipped: Tour Skipped
+Tour completed: Tour completed
+Tour skipped: Tour skipped
+TourCanSkip: TourCanSkip
+User Preferences: User Preferences
+View Menu: View Menu
+Welcome to Paste Menu: Welcome to Paste Menu
+Welcome to PasteBar: Welcome to PasteBar
+Welcome to PasteBar Settings: Welcome to PasteBar Settings
+WelcomeBody: Get ready to simplify your copy and paste workflow with PasteBar! This guided tour will walk you through the key features and show you how to make the most of the app. Let's get started by exploring the Clipboard History Panel.
+WelcomeDescription: Thank you for choosing our application for simplifying your copy-paste workflow and enhancing clipboard functionality. To help you get started and make the most of PasteBar's features, we invite you to take a quick tour of the app.
+WelcomeTour: Let's begin by exploring the clipboard history panel.
+WelcomeTourCanSkip: Or you can <i>Skip Tour</i> if you prefer to explore it on your own. You can always access all tours from the <strong>Help > App Guided Tours</strong> menu in the navigation bar.
+WelcomeTourDescription: Take a tour of this application section to learn about its features and functionality.
+You have completed the tour: You have completed the tour

--- a/nl-NL/history.yaml
+++ b/nl-NL/history.yaml
@@ -1,0 +1,43 @@
+All History Settings: Alle geschiedenisinstellingen
+All done! History's been cleared.: Klaar! De geschiedenis is gewist.
+Auto Update on Capture: Automatisch bijwerken bij vastleggen
+Auto-Clear Settings: Instellingen voor automatisch wissen
+Capture History: Geschiedenis vastleggen
+Clear: Wissen
+Clear All: Alles wissen
+Clear All History: Volledige geschiedenis wissen
+Clear History: Geschiedenis wissen
+Confirm Clear All History: Bevestig volledig wissen van geschiedenis
+Do you really want to remove ALL clipboard history items?: Wilt u echt ALLE klembordgeschiedenisitems verwijderen?
+Do you want to remove all recent clipboard history older than {{olderThen}} {{durationType}}: Wilt u alle recente klembordgeschiedenis ouder dan {{olderThen}} {{durationType}} verwijderen?
+Do you want to remove clipboard history items older than {{olderThen}} {{durationType}}: Wilt u klembordgeschiedenisitems ouder dan {{olderThen}} {{durationType}} verwijderen?
+Enable Capture History: Vastleggen van geschiedenis inschakelen
+Enable Image Capture: Vastleggen van afbeeldingen inschakelen
+Filters:
+  App Filters: App-filters
+  Audio: Audio
+  Clear Filters: Filters wissen
+  Code: Code
+  Emoji: Emoji
+  Image: Afbeelding
+  Language Filters: Taalfilters
+  Languages: Talen
+  Languages Filter: Taalfilter
+  Languages Filters: Taalfilters
+  Link: Link
+  Pinned: Vastgezet
+  Secret: Geheim
+  Select Filters: Filters selecteren
+  Source: Bron
+  Source Application: Bronapplicatie
+  Source Filters: Bronfilters
+  Starred: Gemarkeerd
+  Text: Tekst
+  Video: Video
+Hide pinned history: Vastgezette geschiedenis verbergen
+History Settings: Geschiedenisinstellingen
+Paste Menu: Plakmenu
+Select Filters: Filters selecteren
+View pinned history: Vastgezette geschiedenis bekijken
+'{{isAll}} Clipboard History': '{{isAll}} Klembordgeschiedenis'
+

--- a/nl-NL/menus.yaml
+++ b/nl-NL/menus.yaml
@@ -1,0 +1,30 @@
+Add First Item: Add First Item
+Add Item: Add Item
+Add item: Add item
+Close Edit: Close Edit
+Create Menu: Create Menu
+Delete Menu: Delete Menu
+Disabled Item: Disabled Item
+Disabled Menu: Disabled Menu
+Drag items to reorder, double click to rename: Drag items to reorder, double click to rename
+Enter menu label: Enter menu label
+Find in menu: Find in menu
+Link to Clip: Link to Clip
+Menu: Menu
+Menu Item: Menu Item
+Menu Options: Menu Options
+Menu Type: Menu Type
+Menu is a link to a clip: Menu is a link to a clip
+Menu is link to a clip and cannot be renamed. Please rename its linked clip.: Menu is link to a clip and cannot be renamed. Please rename its linked clip.
+Menus: Menu's
+New Disabled Menu: New Disabled Menu
+New Menu: New Menu
+New Submenu: New Submenu
+No Menu Items: No Menu Items
+No {{hasActive}} menu items in: No {{hasActive}} menu items in
+Select item to add a menu after: Select item to add a menu after
+Separator: Separator
+Submenu: Submenu
+Toggle inactive menu items: Toggle inactive menu items
+active: active
+menu items in: menu items in

--- a/nl-NL/navbar.yaml
+++ b/nl-NL/navbar.yaml
@@ -1,0 +1,44 @@
+Attach History: Attach History
+Audio Player: Audio Player
+Close History: Close History
+Close Main Window: Close Main Window
+Color Theme: Color Theme
+GlobalSearch: 
+  Auto Close on Copy & Paste: Auto Close on Copy & Paste
+  Excludes clip or menu values: Excludes clip or menu values
+  Nothing found in boards.: Nothing found in boards.
+  Nothing found in clips, boards or menus.: Nothing found in clips, boards or menus.
+  Nothing found in clips.: Nothing found in clips.
+  Nothing found in menus.: Nothing found in menus.
+  Press / key to search: Press / key to search
+  Search: Zoeken
+  Search Name or Label Only: Search Name or Label Only
+  Search Options: Search Options
+  Type what you looking for: Type what you looking for
+Help: Help
+Language: Taal
+Lock: Lock
+Lock App Screen: Lock App Screen
+Lock Screen: Lock Screen
+Open PasteBar: Open PasteBar
+Options: Options
+Player: Player
+Show Always on Top: Show Always on Top
+Show Both Panels: Show Both Panels
+Show Clips Panel Only: Show Clips Panel Only
+Show Collections Name: Show Collections Name
+Show History Panel Only: Show History Panel Only
+Swap Panels Layout: Swap Panels Layout
+Theme: 
+  Dark: Donker
+  Light: Licht
+  System: Systeem
+View: View
+Window: 
+  Attach History Window: Attach History Window
+  Attach Window: Attach Window
+  Close Window: Close Window
+  Maximize Window: Maximize Window
+  Minimize Window: Minimize Window
+  Pin Window: Pin Window
+  UnPin Window: UnPin Window

--- a/nl-NL/pinned.yaml
+++ b/nl-NL/pinned.yaml
@@ -1,0 +1,3 @@
+Hide Pinned: Hide Pinned
+Pin: Vastzetten
+Show Pinned: Show Pinned

--- a/nl-NL/settings.yaml
+++ b/nl-NL/settings.yaml
@@ -1,0 +1,220 @@
+<strong>{{screenLockPassCodeLength}}</strong> digits passcode is set.: <strong>{{screenLockPassCodeLength}}</strong> digits passcode is set.
+Activation Success: Activation Success
+Add a star to the copied text when you copy it twice within 1 second. This allows you to quickly add copied text or links to your favorites and easily find it in the clipboard history.: Add a star to the copied text when you copy it twice within 1 second. This allows you to quickly add copied text or links to your favorites and easily find it in the clipboard history.
+Add an unlimited number of tabs within each collection for better organization and easy access.: Add an unlimited number of tabs within each collection for better organization and easy access.
+'Add an unlimited number of tabs within each collection for better organization and easy access.                                ': Add an unlimited number of tabs within each collection for better organization and easy access.                                
+Advanced settings: Advanced settings
+Already Active: Already Active
+Application Auto Start: Application Auto Start
+Application Color Theme: Application Color Theme
+Application UI Color Theme: Application UI Color Theme
+Application UI Fonts Scale: Application UI Fonts Scale
+Application UI Language: Application UI Language
+Applications listed below will not have their copy to clipboard action captured in clipboard history. Case insensitive.: Applications listed below will not have their copy to clipboard action captured in clipboard history. Case insensitive.
+Apply and Restart: Apply and Restart
+Are you sure you want to go back to the default data folder? This will remove the custom location setting.: Are you sure you want to go back to the default data folder? This will remove the custom location setting.
+Are you sure you want to revert to the default database location? The application will restart.: Are you sure you want to revert to the default database location? The application will restart.
+Are you sure you want to set "{{path}}" as the new data folder? The application will restart.: Are you sure you want to set "{{path}}" as the new data folder? The application will restart.
+Are you sure you want to {{operation}} the database to "{{path}}"? The application will restart.: Are you sure you want to {{operation}} the database to "{{path}}"? The application will restart.
+Auto Disable History Capture when Screen Unlocked: Auto Disable History Capture when Screen Unlocked
+Auto Lock Application Screen on User Inactivity: Auto Lock Application Screen on User Inactivity
+Auto Lock Screen on User Inactivity: Auto Lock Screen on User Inactivity
+Auto Lock the Screen on User Inactivity: Auto Lock the Screen on User Inactivity
+Auto Masking Words List: Auto Masking Words List
+Auto update on capture: Auto update on capture
+Auto-Clear Settings: Auto-Clear Settings
+Auto-Generate Link Card Preview: Auto-Generate Link Card Preview
+Auto-Preview Link on Hover: Auto-Preview Link on Hover
+Auto-Star on Double Copy: Auto-Star on Double Copy
+Auto-Trim Spaces on Capture: Auto-Trim Spaces on Capture
+Auto-Update on Capture: Auto-Update on Capture
+Auto-delete clipboard history after: Auto-delete clipboard history after
+Automatically create link card preview in the clipboard history. This allows to quickly view website details without opening or pasting the link.: Automatically create link card preview in the clipboard history. This allows to quickly view website details without opening or pasting the link.
+Back: Back
+Capture History: Capture History
+Capture History Text Length Limits: Capture History Text Length Limits
+Change Custom Data Folder...: Change Custom Data Folder...
+Change Directory...: Change Directory...
+Change Selected Folder...: Change Selected Folder...
+Change the application UI font size scale: Change the application UI font size scale
+Change the application UI language: Change the application UI language
+Change the application user interface color theme: Change the application user interface color theme
+Change the application user interface font size scale: Change the application user interface font size scale
+Change the application user interface language: Change the application user interface language
+Changing the database location requires an application restart to take effect.: Changing the database location requires an application restart to take effect.
+Clip Notes Popup Maximum Dimensions: Clip Notes Popup Maximum Dimensions
+Clipboard History Settings: Clipboard History Settings
+'Complete details: : 'Complete details:
+Configure settings to automatically delete clipboard history items after a specified duration.: Configure settings to automatically delete clipboard history items after a specified duration.
+ConfirmRevertToDefaultDbPathMessage: Are you sure you want to revert to the default data location? Your application data will be moved to the default path.
+Copy data: Copy data
+Copy database file: Copy database file
+Create a preview card on link hover in the clipboard history. This allows you to preview the link before opening or pasting it.: Create a preview card on link hover in the clipboard history. This allows you to preview the link before opening or pasting it.
+Create an unlimited number of collections to organize your clips and menus.: Create an unlimited number of collections to organize your clips and menus.
+Current data folder: Current data folder
+Current data location: Current data location
+Current database location: Current database location
+Custom: Custom
+Custom Application Data Location: Custom Application Data Location
+Custom Database Location: Custom Database Location
+Custom data location is active. You can change it or revert to the default location. Changes require an application restart.: Custom data location is active. You can change it or revert to the default location. Changes require an application restart.
+Custom themes: Custom themes
+Decrease UI Font Size: Decrease UI Font Size
+Default: Default
+Disable Image Capture: Disable Image Capture
+Disable capturing and storing images from clipboard: Disable capturing and storing images from clipboard
+Display clipboard history capture toggle on the locked application screen. This allows you to control history capture settings directly from the lock screen.: Display clipboard history capture toggle on the locked application screen. This allows you to control history capture settings directly from the lock screen.
+Display disabled collections name on the navigation bar collections menu: Display disabled collections name on the navigation bar collections menu
+Display disabled collections name on the navigation bar under collections menu: Display disabled collections name on the navigation bar under collections menu
+Display full name of selected collection on the navigation bar: Display full name of selected collection on the navigation bar
+Do you want to attempt to move the database file from "{{customPath}}" back to the default location?: Do you want to attempt to move the database file from "{{customPath}}" back to the default location?
+Drag and drop to prioritize languages for detection. The higher a language is in the list, the higher its detection priority.: Drag and drop to prioritize languages for detection. The higher a language is in the list, the higher its detection priority.
+Email: Email
+Email is not valid: Email is not valid
+'Email: : 'Email:
+Emails do not match: Emails do not match
+Enable Auto Start: Enable Auto Start
+Enable Clip Title Hover Show with Delay: Enable Clip Title Hover Show with Delay
+Enable application auto start on system boot: Enable application auto start on system boot
+Enable auto lock the application screen after a certain period of inactivity, to prevent unauthorized access to your data.: Enable auto lock the application screen after a certain period of inactivity, to prevent unauthorized access to your data.
+Enable auto lock the application screen when user not active: Enable auto lock the application screen when user not active
+Enable auto trim spaces on history capture: Enable auto trim spaces on history capture
+Enable auto update on capture: Enable auto update on capture
+Enable custom data location to store application data in a directory of your choice instead of the default location.: Enable custom data location to store application data in a directory of your choice instead of the default location.
+Enable history capture: Enable history capture
+Enable programming language detection: Enable programming language detection
+Enable screen unlock requirement on app launch for enhanced security, safeguarding data from unauthorized access.: Enable screen unlock requirement on app launch for enhanced security, safeguarding data from unauthorized access.
+Enter Passcode length: Enter Passcode length
+Enter new directory path or leave empty for default on next revert: Enter new directory path or leave empty for default on next revert
+Enter recovery password to reset passcode.: Enter recovery password to reset passcode.
+Enter your <strong>{{screenLockPassCodeLength}} digits</strong> passcode: Enter your <strong>{{screenLockPassCodeLength}} digits</strong> passcode
+Entered Passcode is invalid: Entered Passcode is invalid
+Excluded Apps List: Excluded Apps List
+Execute Web Requests: Execute Web Requests
+Execute terminal or shell commands directly from PasteBar clip and copy the results to the clipboard.: Execute terminal or shell commands directly from PasteBar clip and copy the results to the clipboard.
+'Expires: : 'Expires:
+Failed to revert to default database location.: Failed to revert to default database location.
+Failed to select directory: Failed to select directory
+Forgot Passcode ? Enter your recovery password to reset the passcode.: Forgot Passcode ? Enter your recovery password to reset the passcode.
+Forgot passcode ?: Forgot passcode ?
+Forgot?: Forgot?
+Forgot? Reset using Password: Forgot? Reset using Password
+Get priority email support from us to resolve any issues or questions you may have about PasteBar.: Get priority email support from us to resolve any issues or questions you may have about PasteBar.
+'Hint: {{screenLockRecoveryPasswordMasked}}': 'Hint: {{screenLockRecoveryPasswordMasked}}
+If a database file already exists at the default location, do you want to overwrite it? Choosing "Cancel" will skip moving the file if an existing file is found.: If a database file already exists at the default location, do you want to overwrite it? Choosing "Cancel" will skip moving the file if an existing file is found.
+Incorrect passcode.: Incorrect passcode.
+Increase UI Font Size: Increase UI Font Size
+Issued: Issued
+Large: Large
+List each application name or window identifier on a new line.: List each application name or window identifier on a new line.
+List each word or sentence on a new line.: List each word or sentence on a new line.
+Lock Screen Clipboard History Capture Control: Lock Screen Clipboard History Capture Control
+Lock Screen PassCode: Lock Screen PassCode
+Lock Screen Passcode: Lock Screen Passcode
+Manage Collections: Manage Collections
+Maximum 10 digits: Maximum 10 digits
+Maximum devices: Maximum devices
+Medium: Medium
+Minimal 4 digits: Minimal 4 digits
+Minimize Window: Minimize Window
+Minimum number of lines to trigger detection: Minimum number of lines to trigger detection
+Move data: Move data
+Move database file: Move database file
+Name: Name
+New Data Directory Path: New Data Directory Path
+New Database Directory Path: New Database Directory Path
+Open Security Settings: Open Security Settings
+Operation when applying new path: Operation when applying new path
+Passcode digits remaining: Passcode digits remaining
+Passcode is locked.: Passcode is locked.
+Passcode is not set: Passcode is not set
+Passcode is not valid: Passcode is not valid
+Passcode length: Passcode length
+Passcode mismatch: Passcode mismatch
+Passcode reset is locked.: Passcode reset is locked.
+Passcode successfully verified: Passcode successfully verified
+Passcode verification error: Passcode verification error
+Passcode verification is locked.: Passcode verification is locked.
+Password is incorrect.: Password is incorrect.
+Password is incorrect. <br/>{{screenLockRecoveryPasswordMasked}}: Password is incorrect. <br/>{{screenLockRecoveryPasswordMasked}}
+'Password is incorrect. Hint: {{screenLockRecoveryPasswordMasked}}': 'Password is incorrect. Hint: {{screenLockRecoveryPasswordMasked}}
+'Password is incorrect. Masked password is: {{screenLockRecoveryPasswordMasked}}': 'Password is incorrect. Masked password is: {{screenLockRecoveryPasswordMasked}}
+Password is incorrect. {{screenLockRecoveryPasswordMasked}}: Password is incorrect. {{screenLockRecoveryPasswordMasked}}
+Passwords do not match: Passwords do not match
+PasteBar Settings: PasteBar Settings
+Pin Window: Pin Window
+Pin on Top Window: Pin on Top Window
+Please set up a Passcode and recovery password in Security Settings to enable Screen Lock and ensure better security.: Please set up a Passcode and recovery password in Security Settings to enable Screen Lock and ensure better security.
+Please try again: Please try again
+Preview current popup size on hover.: Preview current popup size on hover.
+Prioritize Language Detection: Prioritize Language Detection
+Priority support: Priority support
+Programming Language Detection: Programming Language Detection
+Programming Language Selection: Programming Language Selection
+Protect your data by requiring screen unlock authentication whenever the application starts.: Protect your data by requiring screen unlock authentication whenever the application starts.
+Recovery Password for Lock Screen Passcode: Recovery Password for Lock Screen Passcode
+Recovery password is set.: Recovery password is set.
+Refresh Application UI: Refresh Application UI
+Refresh UI: Refresh UI
+Require Screen Unlock at Application Start: Require Screen Unlock at Application Start
+Require screen unlock at application launch to enhance security. This setting ensures that only authorized users can access the application, protecting your data from unauthorized access right from the start.: Require screen unlock at application launch to enhance security. This setting ensures that only authorized users can access the application, protecting your data from unauthorized access right from the start.
+Reset Font Size: Reset Font Size
+Revert to Default: Revert to Default
+Revert to Default and Restart: Revert to Default and Restart
+Run Terminal or Shell Commands: Run Terminal or Shell Commands
+Scrape and parse websites or API responses using built-in web scraping tools and copy the extracted data to the clipboard.: Scrape and parse websites or API responses using built-in web scraping tools and copy the extracted data to the clipboard.
+'Scrape and parse websites or API responses using built-in web scraping tools and copy the extracted data to the clipboard.                                ': Scrape and parse websites or API responses using built-in web scraping tools and copy the extracted data to the clipboard.                                
+Security: Security
+Security Settings: Security Settings
+Select Custom Data Folder...: Select Custom Data Folder...
+Select Data Folder: Select Data Folder
+Select Data Folder...: Select Data Folder...
+Select a custom location to store your application data instead of the default location.: Select a custom location to store your application data instead of the default location.
+Selected data folder: Selected data folder
+Selected new data folder: Selected new data folder
+Selected new data folder for change: Selected new data folder for change
+Send HTTP requests to web APIs or services and copy the response data to the clipboard.: Send HTTP requests to web APIs or services and copy the response data to the clipboard.
+Sensitive words or sentences listed below will automatically be masked if found in the copied text. Case insensitive.: Sensitive words or sentences listed below will automatically be masked if found in the copied text. Case insensitive.
+Set a passcode to unlock the locked screen and protect your data from unauthorized access.: Set a passcode to unlock the locked screen and protect your data from unauthorized access.
+Set a recovery password to easily reset your lock screen passcode if forgotten. Your password will be securely stored in your device's OS storage.: Set a recovery password to easily reset your lock screen passcode if forgotten. Your password will be securely stored in your device's OS storage.
+Setting a custom database location requires an application restart to take effect.: Setting a custom database location requires an application restart to take effect.
+Settings: Instellingen
+Show Clipboard History Capture Control on Lock Screen: Show Clipboard History Capture Control on Lock Screen
+Show Disable History Capture When Screen Locked: Show Disable History Capture When Screen Locked
+Show Disabled Collections: Show Disabled Collections
+Show clipboard history capture toggle when the application screen is locked. This allow you to control capturing history settings from the application locked screen.: Show clipboard history capture toggle when the application screen is locked. This allow you to control capturing history settings from the application locked screen.
+Show collection name on the navbar: Show collection name on the navbar
+Show disabled collections on the navbar list: Show disabled collections on the navbar list
+Skip auto start prompt on app launch: Skip auto start prompt on app launch
+Small: Small
+Stop Words List: Stop Words List
+Swap Panels Layout: Swap Panels Layout
+Switch the layout position of panels in Clipboard History and Paste Menu views: Switch the layout position of panels in Clipboard History and Paste Menu views
+Thank you again for using PasteBar.: Thank you again for using PasteBar.
+Thank you for testing! 🙌: Thank you for testing! 🙌
+The selected folder is not empty and does not contain PasteBar data files. Do you want to create a "pastebar-data" subfolder to store the data?: The selected folder is not empty and does not contain PasteBar data files. Do you want to create a "pastebar-data" subfolder to store the data?
+The selected folder is not empty. Do you want to create a "pastebar-data" subfolder to store the data?: The selected folder is not empty. Do you want to create a "pastebar-data" subfolder to store the data?
+This folder already contains PasteBar data. The application will use this existing data after restart.: This folder already contains PasteBar data. The application will use this existing data after restart.
+This option lets you control the display and timing of hover notes on clips. You can choose to show notes instantly or with a delay to prevent unintended popups.: This option lets you control the display and timing of hover notes on clips. You can choose to show notes instantly or with a delay to prevent unintended popups.
+This option lets you customize the maximum width and height of the popup that displays clip notes, ensuring it fits comfortably within your desired size.: This option lets you customize the maximum width and height of the popup that displays clip notes, ensuring it fits comfortably within your desired size.
+This option lets you customize the minimum and maximum length of text that can be captured in the clipboard history. Setting either value to 0 makes that limit unlimited.: This option lets you customize the minimum and maximum length of text that can be captured in the clipboard history. Setting either value to 0 makes that limit unlimited.
+To downgrade your current version, please visit: To downgrade your current version, please visit
+'To downgrade, please visit: : 'To downgrade, please visit: 
+To ensure the best detection accuracy, please select up to 7 languages. Limiting choices improves precision.: To ensure the best detection accuracy, please select up to 7 languages. Limiting choices improves precision.
+Today: Today
+Tomorrow: Tomorrow
+Try after <strong>{{resetPassCodeNextDelay}}</strong> seconds: Try after <strong>{{resetPassCodeNextDelay}}</strong> seconds
+Try again after <strong>{{resetPassCodeNextDelay}}</strong> seconds: Try again after <strong>{{resetPassCodeNextDelay}}</strong> seconds
+UI Language: UI Language
+UnPin Window: UnPin Window
+Unlimited Collections: Unlimited Collections
+Unlimited Tabs per Collection: Unlimited Tabs per Collection
+Unlimited paste history: Unlimited paste history
+Use Password: Use Password
+Use new location: Use new location
+User Preferences: User Preferences
+Web Scraping and Parsing: Web Scraping and Parsing
+Words or sentences listed below will not be captured in clipboard history if found in the copied text. Case insensitive.: Words or sentences listed below will not be captured in clipboard history if found in the copied text. Case insensitive.
+none: none
+passcode reset: passcode reset
+password reset: password reset

--- a/nl-NL/settings2.yaml
+++ b/nl-NL/settings2.yaml
@@ -1,0 +1,82 @@
+App restart required: Restart required
+Application Starts with Main Window Hidden: Application Starts with Main Window Hidden
+Auto-close window after action: Auto-close window after action
+Boards, saved clips and menu items panel visible: Boards, saved clips and menu items panel visible
+Both clipboard history and saved clips panels visible: Both clipboard history and saved clips panels visible
+Change: Change
+Click Set/Change button to start recording: Click Set/Change button to start recording
+Clipboard history panel visible: Clipboard history panel visible
+Configure how the system tray icon responds to mouse clicks: Configure how the system tray icon responds to mouse clicks
+Configure the behavior of the Quick Paste window when selecting items: Configure the behavior of the Quick Paste window when selecting items
+Configure which items to preserve when clearing clipboard history (both manual and auto-clear operations).: Configure which items to preserve when clearing clipboard history (both manual and auto-clear operations).
+Control which panels are visible in the main window: Control which panels are visible in the main window
+Copy items only (no auto-paste): Copy items only (no auto-paste)
+Copy only from menu items: Copy only from menu items
+Default Note Icon Type: Default Note Icon Type
+Disable left-click context menu: Disable left-click context menu
+Display navbar items only when the mouse hovers over the navigation bar to minimize visible UI elements: Display navbar items only when the mouse hovers over the navigation bar to minimize visible UI elements
+Display persistent icons on clips that have notes to improve visual organization and make notes easier to discover.: Display persistent icons on clips that have notes to improve visual organization and make notes easier to discover.
+Double-click toggles app visibility: Double-click toggles app visibility
+Double-clicking the tray icon shows or hides the main application window: Double-clicking the tray icon shows or hides the main application window
+Enable simplified, less boxy layout for a cleaner and more streamlined interface design: Enable simplified, less boxy layout for a cleaner and more streamlined interface design
+Enable single-click to copy/paste clipboard history items and saved clips instead of requiring double-click.: Enable single-click to copy/paste clipboard history items and saved clips instead of requiring double-click.
+Enabling either left-click option will disable the context menu to ensure proper functionality.: Enabling either left-click option will disable the context menu to ensure proper functionality.
+Global System OS Hotkeys: Global System OS Hotkeys
+Hide Collections Navbar: Hide Collections Navbar
+Hide collections menu dropdown on the navigation bar: Hide collections menu dropdown on the navigation bar
+Hide collections menu on the navbar: Hide collections menu on the navbar
+Hide the App Dock Icon: Hide the App Dock Icon
+History Item Preview Max Lines: History Item Preview Max Lines
+'How to set hotkeys: : 'How to set hotkeys:
+Keep Items on Clear: Keep Items on Clear
+Keep Pinned Items: Keep Pinned Items
+Keep Starred Items: Keep Starred Items
+? Keep the main application window hidden when the app restarts. You can reopen it using the menu bar or taskbar menu, or using global hotkeys.
+: Keep the main application window hidden when the app restarts. You can reopen it using the menu bar or taskbar menu, or using global hotkeys.
+Left-click toggles app visibility: Left-click toggles app visibility
+Left-clicking the tray icon shows or hides the main application window: Left-clicking the tray icon shows or hides the main application window
+No keys set: No keys set
+'Note: At least one panel must remain visible in main window.': 'Note: At least one panel must remain visible in main window.
+Panel Visibility: Panel Visibility
+PasteBar Quick Paste: PasteBar Quick Paste
+Preserve pinned items when clearing history: Preserve pinned items when clearing history
+Preserve starred items when clearing history: Preserve starred items when clearing history
+Press Backspace/Delete to clear the hotkey: Press Backspace/Delete to clear the hotkey
+Press Enter to confirm or Escape to cancel: Press Enter to confirm or Escape to cancel
+Press keys: Press keys
+Press your desired key combination (e.g., Ctrl+Shift+V): Press your desired key combination (e.g., Ctrl+Shift+V)
+Press your key combination...: Press your key combination...
+Prevents the context menu from appearing when left-clicking the tray icon: Prevents the context menu from appearing when left-clicking the tray icon
+Preview Max Lines: Preview Max Lines
+Quick Paste Window: Quick Paste Window
+Quick Paste Window Options: Quick Paste Window Options
+Recording...: Recording...
+? Remove PasteBar app icon from the macOS Dock while keeping the app running in the background. The app remains accessible via the menu bar icon. Requires an app restart to take effect.
+: Remove PasteBar app icon from the macOS Dock while keeping the app running in the background. The app remains accessible via the menu bar icon. Requires an app restart to take effect.
+Set: Set
+Set system OS hotkeys to show/hide the main app window and quick paste window. Supports up to 3-key combinations.: Set system OS hotkeys to show/hide the main app window and quick paste window. Supports up to 3-key combinations.
+Set the maximum number of lines to display in the preview of a history item: Set the maximum number of lines to display in the preview of a history item
+Show Boards and Clips Panel Only: Show Boards and Clips Panel Only
+Show Both Panels: Show Both Panels
+Show History Panel Only: Show History Panel Only
+Show Navbar Items Hover: Show Navbar Items Hover
+Show Note Icons on Clips: Show Note Icons on Clips
+Show Simplified Layout: Show Simplified Layout
+Show collections menu on the navbar: Show collections menu on the navbar
+Show navbar elements on hover only: Show navbar elements on hover only
+Show/Hide Main App Window: Show/Hide Main App Window
+Show/Hide Quick Paste Window: Show/Hide Quick Paste Window
+Simplified Panel Layout: Simplified Panel Layout
+Single Click Copy/Paste: Single Click Copy/Paste
+Single Click Copy/Paste action: Single Click Copy/Paste action
+Set keyboard focus with a single click. Disables single-click copy/paste if set.: Set keyboard focus with a single click. Disables single-click copy/paste if set.
+Single-Click Keyboard Focus: Single-Click Keyboard Focus
+This sets the default icon type for new clips with notes. You can customize individual clips via the context menu.: This sets the default icon type for new clips with notes. You can customize individual clips via the context menu.
+Tray Icon Behavior on Windows: Tray Icon Behavior on Windows
+? When enabled, clicking menu items will only copy content to clipboard instead of auto-pasting. This gives you more control over when and where content is pasted.
+: When enabled, clicking menu items will only copy content to clipboard instead of auto-pasting. This gives you more control over when and where content is pasted.
+? When enabled, clicking or pressing Enter on items in Quick Paste window will only copy them to clipboard without automatically pasting.
+: When enabled, clicking or pressing Enter on items in Quick Paste window will only copy them to clipboard without automatically pasting.
+? When enabled, single click will copy/paste items in Quick Paste window. If global single click is also enabled, both settings work together.
+: When enabled, single click will copy/paste items in Quick Paste window. If global single click is also enabled, both settings work together.
+When enabled, the Quick Paste window will automatically close after copying or pasting an item.: When enabled, the Quick Paste window will automatically close after copying or pasting an item.

--- a/nl-NL/specailCopyPaste.yaml
+++ b/nl-NL/specailCopyPaste.yaml
@@ -1,0 +1,1 @@
+Special Settings: Special Settings

--- a/nl-NL/specialCopyPaste.yaml
+++ b/nl-NL/specialCopyPaste.yaml
@@ -1,0 +1,74 @@
+Add Current Date/Time: Add Current Date/Time
+Add Line Numbers: Add Line Numbers
+Add One Line Feed: Add One Line Feed
+Add Two Line Feeds: Add Two Line Feeds
+Base64 Decode: Base64 Decode
+Base64 Encode: Base64 Encode
+CSV: CSV
+CSV to JSON: CSV to JSON
+CSV to Markdown Table: CSV to Markdown Table
+Capitalize Case: Capitalize Case
+Code Formatting: Code Formatting
+Count Characters: Count Characters
+Count Lines: Count Lines
+Count Sentences: Count Sentences
+Count Words: Count Words
+Data Conversion: Data Conversion
+Drag and drop category to prioritize its order in the special copy/paste menu.: Drag and drop category to prioritize its order in the special copy/paste menu.
+Enable All: Enable All
+Enable special text transformation options for clipboard history items: Enable special text transformation options for clipboard history items
+Enabled Operations: Enabled Operations
+Encode/Decode: Encode/Decode
+Format Converter: Format Converter
+HTML: HTML
+HTML Decode: HTML Decode
+HTML Encode: HTML Encode
+HTML to Markdown: HTML to Markdown
+HTML to Plain Text: HTML to Plain Text
+HTML to React Component: HTML to React Component
+HTML to React JSX: HTML to React JSX
+HTML to Text: HTML to Text
+JSON: JSON
+JSON Stringify: JSON Stringify
+JSON to CSV: JSON to CSV
+JSON to Markdown Table: JSON to Markdown Table
+JSON to TOML: JSON to TOML
+JSON to XML: JSON to XML
+JSON to YAML: JSON to YAML
+Markdown: Markdown
+Markdown to HTML: Markdown to HTML
+Markdown to Text: Markdown to Text
+Operations: Operations
+PascalCase: PascalCase
+Prioritize Category Order: Prioritize Category Order
+PrioritizeCategoryOrderNote: PrioritizeCategoryOrderNote
+Remove Duplicate Lines: Remove Duplicate Lines
+Remove Extra Spaces: Remove Extra Spaces
+Remove Line Feeds: Remove Line Feeds
+Reverse Text: Reverse Text
+Select Operations: Select Operations
+Sentence case: Sentence case
+Sort Lines Alphabetically: Sort Lines Alphabetically
+Special Copy: Special Copy
+Special Copy/Paste Operations: Special Copy/Paste Operations
+Special Paste: Special Paste
+Special Settings: Special Settings
+TOML: TOML
+TOML to JSON: TOML to JSON
+Text Case: Text Case
+Text Tools: Text Tools
+Title Case: Title Case
+Trim White Space: Trim White Space
+UPPER CASE: UPPER CASE
+URL Decode: URL Decode
+URL Encode: URL Encode
+Whitespace & Lines: Whitespace & Lines
+XML: XML
+XML to JSON: XML to JSON
+YAML: YAML
+YAML to JSON: YAML to JSON
+camelCase: camelCase
+iNVERT cASE: iNVERT cASE
+kebab-case: kebab-case
+lower case: lower case
+snake_case: snake_case

--- a/nl-NL/templates.yaml
+++ b/nl-NL/templates.yaml
@@ -1,0 +1,24 @@
+Create New Template: Create New Template
+Create Template: Create Template
+Enter template content...: Enter template content...
+Enter template name (e.g., "signature", "email"): Enter template name (e.g., "signature", "email")
+Global: Global
+Global Template: Global Template
+Global Templates: Global Templates
+Preview usage: Preview usage
+Template Usage: Template Usage
+Template name already exists: Template name already exists. Please choose a different name.
+Template name cannot be changed after creation. Delete and recreate to change name.: Template name cannot be changed after creation. Delete and recreate to change name.
+Use Global Template: Use Global Template
+addTemplateButton: Add Template
+confirmDeleteTemplateMessage: Are you sure you want to delete the global template '{{name}}'?
+confirmDeleteTemplateTitle: Confirm Delete
+deleteTemplateButtonTooltip: Delete Template
+enableGlobalTemplatesLabel: Enable Global Templates
+globalTemplatesDescription: Manage reusable text snippets that can be inserted into any clip using {{template_name}}.
+globalTemplatesTitle: Global Templates
+localTemplateConflictWarning: A global template named '{{label}}' also exists. The local template will take precedence within this clip's form.
+noGlobalTemplatesYet: No global templates defined yet. Click 'Add Template' to create one.
+templateEnabledLabel: Enabled
+templateNameLabel: Name
+templateValueLabel: Value

--- a/nl-NL/tours.yaml
+++ b/nl-NL/tours.yaml
@@ -1,0 +1,241 @@
+HISTORY_PANEL_TOUR: 
+  - element: #side-panel_tour
+    popover: 
+      title: Clipboard History Panel
+      description: This panel displays your copied clipboard history for easy access later. Scroll through your history, search for content, or filter by type. You can resize this panel for a customized view.
+      prefferedSide: right
+  - element: #history-find_tour
+    popover: 
+      title: Find and Filter History
+      description: Use the search to quickly find specific items in your clipboard history. Filter results by type (text, images, or links) to easily locate what you need. Copy a found item again or save it to the board.
+      prefferedSide: bottom
+      alignment: center
+  - element: #history-list_tour .history-item
+    popover: 
+      title: Clipboard History Item
+      description: Each item in your Clipboard History represents content you've previously copied. <b>Double-click</b> an item or click the icon to copy it back to the clipboard. <b>Press and drag</b> to create a saved clip on the board panel. <b>Right-click</b> an item for more options in the context menu.
+      prefferedSide: right
+  - element: #tabs-history_tour
+    meta: 
+      closeTourCssPosition: hidden
+    popover: 
+      title: History/Menu Navigation Tabs
+      description: Switch between Clipboard History and Paste Menu views for easy management and access of your content.
+      alignment: center
+      prefferedSide: top
+  - element: #history-menu-button_tour
+    meta: 
+      closeTourCssPosition: hidden
+    popover: 
+      title: History Selected Items Menu
+      description: Use this menu to manage selected items in your Clipboard History. You can <b>multi-select</b> items, deselect all, add to board, delete, or clear history for specific dates.
+      alignment: end
+      prefferedSide: right
+  - element: .panel-resize_tour
+    popover: 
+      title: Resizable Panel View
+      description: Customize your workspace by resizing the panel view to fit your preferences. <b>Hover your mouse</b> over the edge of the panel until the resize cursor appears, then <b>click and drag</b> to adjust the panel size.
+      prefferedSide: right
+
+DASHBOARD_CLIPS_TOUR: 
+  - element: .clips-dashboard-panel_tour
+    meta: 
+      closeTourCssPosition: hidden
+    popover: 
+      title: Dashboard Panel
+      description: This panel provides a central hub for organizing and managing your saved clips. Create custom tabs and boards to structure your content. <b>Drag and drop</b> items from your Clipboard History to create new clips. Use tabs to switch between different board categories.
+      prefferedSide: left
+  - element: #dashboard-tabs_tour
+    popover: 
+      title: Dashboard Tabs
+      description: Create custom tabs and use them to navigate through different sections of your Dashboard. Switch between categories to manage and access your clips and content quickly.
+      alignment: center
+      prefferedSide: bottom
+  - element: #dashboard-tabs-create-button_tour
+    popover: 
+      title: Create Dashboard Items
+      description: Create new items for your Dashboard. Add clips, boards, or custom tabs to organize your content.
+      alignment: end
+      prefferedSide: bottom
+  - element: #dashboard-tabs-context-menu_tour
+    popover: 
+      title: Tabs and Layout Menu
+      description: <b>Right-click</b> on the tabs or <b>click the menu icon</b> to organize your layout and manage your tabs. You can edit existing tabs or change the dashboard layout to suit your workflow preferences.
+      alignment: end
+      prefferedSide: bottom
+  - element: .board-panel_tour
+    popover: 
+      title: Board Panel
+      description: This board panel allows you to organize your saved clips for quick and easy access. <b>Drag and drop</b> items from your Clipboard History. Use boards to categorize and manage your content efficiently.
+      alignment: center
+      prefferedSide: right
+  - element: .board-panel-header_tour
+    popover: 
+      title: Board Panel Header
+      description: <b>Double-click</b> the header to quickly expand the board panel or <b>right-click</b> to see other options to customize and manage the board.
+      alignment: start
+      prefferedSide: right
+  - element: .clip_tour
+    popover: 
+      title: Saved Clip Item
+      description: Access saved clip content quickly. <b>Double-click</b> or <b>click the clipboard icon</b> to copy it. <b>Long-press</b> to rearrange items, or <b>right-click</b> for more options to customize and organize your clip.
+      alignment: start
+      prefferedSide: right
+  - element: .panel-resize_tour
+    popover: 
+      title: Resizable Panel View
+      description: Customize your workspace by resizing the panel view to fit your preferences. <b>Hover your mouse</b> over the edge of the panel until the resize cursor appears, then <b>click and drag</b> to adjust the panel size.
+      prefferedSide: right
+
+MENU_TOUR: 
+  - element: #side-panel_tour
+    popover: 
+      title: Paste Menu Panel
+      description: This panel allows you to manage your system's taskbar or menubar native paste menu. <b>Hold and drag</b> items to rearrange them, <b>double-click</b> to rename. <b>Press</b> ALT or Command key and click any item to multi-select.
+      prefferedSide: right
+  - element: #menu-find_tour
+    popover: 
+      title: Find Menu Items
+      description: Use the search bar to quickly find specific menu items. Type in keywords to filter and locate the items you need.
+      prefferedSide: bottom
+      alignment: center
+  - element: div[role=treeitem]
+    popover: 
+      title: Menu Item Tree
+      description: Each item in menu tree can be rearranged individually or in group. <b>Double-click</b> to rename, <b>hold and drag</b> to rearrange it. <b>Press</b> ALT or Command key and click to multi-select.
+      prefferedSide: right
+  - element: #tabs-menu_tour
+    meta: 
+      closeTourCssPosition: hidden
+    popover: 
+      title: History/Menu Navigation Tabs
+      description: Switch between Clipboard History and Paste Menu views for easy management and access of your content.
+      alignment: center
+      prefferedSide: top
+  - element: #menu-icon-menu-button_tour
+    meta: 
+      closeTourCssPosition: hidden
+    popover: 
+      title: Selected Items Paste Menu
+      description: Use this menu to manage multiple selected menu items. Multi-select, deselect all, rebuild the native menu, or delete items to quickly organize your paste menu.
+      alignment: end
+      prefferedSide: right
+  - element: #menu-main-list_tour
+    meta: 
+      closeTourCssPosition: hidden
+    popover: 
+      title: Manage Paste Menu Panel
+      description: This panel allows you to manage all active menu items. Add, edit, or remove items to customize your paste menu. Create new items or link existing clips. <b>Double-click</b> to copy content to the clipboard and <b>right-click</b> for more options.
+      alignment: start
+      prefferedSide: left
+  - element: .menu-item_tour
+    popover: 
+      title: Menu Item
+      description: Here you can manage each menu item individually. <b>Click</b> the expand icon to see menu content. <b>Double-click</b> to copy content to the clipboard and <b>right-click</b> to see more options.
+      alignment: center
+      prefferedSide: bottom
+  - element: #add-menu-item__tour
+    popover: 
+      title: Add Menu Item
+      description: Click the plus icon and choose the location where you want to add the new item, before or after the existing menu item. You can create a new menu, submenus, separators, disabled menu items, menu items from recent history, or a link to a saved clip.
+      alignment: end
+      prefferedSide: bottom
+  - element: #toggle-inactive-menu-items_tour
+    popover: 
+      title: Toggle Inactive Menu Items
+      description: Click this icon to show or hide inactive menu items. This helps to manage and organize your menu by focusing on active items when needed. Streamline your menu and declutter your workspace for improved efficiency.
+      alignment: start
+      prefferedSide: bottom
+  - element: .panel-resize_tour
+    popover: 
+      title: Resizable Panel View
+      description: Customize your workspace by resizing the panel view to fit your preferences. <b>Hover your mouse</b> over the edge of the panel until the resize cursor appears, then <b>click and drag</b> to adjust the panel size.
+      prefferedSide: right
+
+NAVBAR_TOUR: 
+  - element: #navbar-panel_tour
+    popover: 
+      title: Navigation Bar
+      description: The navigation bar provides quick access to PasteBar's features and settings. Use it to switch between the Clipboard History and Paste Menus views, access your collections, perform a global search, toggle pinned board visibility, adjust settings, and get help when needed.
+      alignment: center
+      prefferedSide: bottom
+  - element: #navbar-pastebar_tour
+    popover: 
+      title: PasteBar Menu
+      description: The PasteBar menu provides quick access to essential functions and information. Here you can check for updates, access settings, lock the app screen, close the main window, or quit the application.
+      alignment: start
+      prefferedSide: bottom
+  - element: #navbar-view_tour
+    popover: 
+      title: View Menu
+      description: Use the View menu to navigate your clipboard history and paste menu, adjust options, change the color theme, modify the UI font size, and change the language. Access additional settings for a personalized experience.
+      alignment: start
+      prefferedSide: bottom
+  - element: #navbar-collections_tour
+    popover: 
+      title: Collections Menu
+      description: The Collections Menu allows you to switch between different collections of clips, boards, and tabs. Create and customize each collection to suit your specific needs, such as organizing content by project or category.
+      alignment: center
+      prefferedSide: bottom
+  - element: #navbar-toggle-history-split
+    popover: 
+      title: Toggle History Window
+      description: Click this icon to open or close the clipboard history in a separate window. Use this feature to manage your clipboard history independently from the main window.
+      alignment: center
+      preferredSide: bottom
+  - element: #navbar-search_tour
+    popover: 
+      title: Global Search
+      description: Use the global search to quickly find clips, boards, and menu items across the active collection. Type keywords to filter results and locate the content you need efficiently. <b>Double-click</b> a clip to copy it directly from the search results.
+      alignment: center
+      prefferedSide: bottom
+  - element: #navbar-pinned_tour
+    popover: 
+      title: Toggle Pinned Board
+      description: Click this icon to show or hide the pinned board. Use this feature to keep your workspace organized and focus on the most relevant content.
+      alignment: end
+      prefferedSide: bottom
+  - element: #navbar-help_tour
+    popover: 
+      title: Help Menu
+      description: Quickly access guided tours and UI feature showcases from the Help menu. It provides step-by-step guidance and demonstrations to help you navigate and understand PasteBar's features and user interface effectively.
+      alignment: end
+      prefferedSide: bottom
+  - element: #navbar-close-window_tour
+    popover: 
+      title: Close Main Window
+      description: Click the close icon to close the main PasteBar window while keeping its functionality available from the taskbar or menubar icon. You can always reopen the main application window from the main menu.
+      alignment: end
+      prefferedSide: bottom
+
+SETTINGS_TOUR: 
+  - element: #app-settings-history_tour
+    popover: 
+      title: Clipboard History Settings
+      description: Adjust your clipboard history settings to customize how PasteBar captures and manages your copied content. Enable or disable features like auto-update, auto-star, link preview, stop words list, and programming language auto-detection for a personalized experience.
+      alignment: start
+      prefferedSide: right
+  - element: #app-settings-collections_tour
+    popover: 
+      title: Manage Collections Settings
+      description: Use the Manage Collections to organize and customize your collections. Add new collections, edit existing ones, and switch between them to suit your workflow. Manage your content efficiently by grouping related clips, boards, and tabs.
+      alignment: start
+      prefferedSide: right
+  - element: #app-settings-preferences_tour
+    popover: 
+      title: User Preferences
+      description: Adjust font size, switch color themes, change the interface language, and configure auto-start options. Swap panel layouts, show collection names on the navbar, and manage clip note popups.
+      alignment: start
+      prefferedSide: right
+  - element: #app-settings-security_tour
+    popover: 
+      title: Security Settings
+      description: Configure your security settings to protect your data. Set a lock screen passcode and recovery password. Control clipboard history capture from the lock screen and enable auto-lock on inactivity. Adjust these settings to enhance the security of your PasteBar application.
+      alignment: start
+      prefferedSide: right
+  - element: #app-settings-back_tour
+    popover: 
+      title: Return to the Main Screen
+      description: Click to return from settings to the main application view.
+      alignment: start
+      prefferedSide: right

--- a/nl-NL/updaterl.yaml
+++ b/nl-NL/updaterl.yaml
@@ -1,0 +1,30 @@
+Check for Update: Check for App Update
+Checking for Update...: Checking for Update...
+Confirm Restart: Confirm Restart
+Confirm Update: Confirm Update
+Download Completed: Download Completed
+Download Completed Quit and Manually Install: The downloaded update file should automatically open. To complete the update, first quit the PasteBar application then manually complete the installation of the latest version. Once the installation is complete, start PasteBar using the updated version.
+Download Update: Download Update
+Downloading...: Downloading...
+General Update Error: An error occurred during the update process. Please try updating again later. If the issue persists, you should manually download and install the update.
+Install Update: Install Update
+Installing Update: Installing Update
+No Update Available: No Update Available
+Permission Denied Message: The update process was unable to replace the old application files due to insufficient privileges. You have to manually download and update the application files using a user account with administrator privileges.
+Quit PasteBar: Quit PasteBar
+Release date {{date}}: Release date {{date}}
+Remind Me Later: Remind Me Later
+Restart: Restart
+Restart Required: Restart Required
+Restart to Finish: Restart to Finish
+Restart to Update: Restart PasteBar
+Skip Download: Skip Download
+Skip This Version: Skip This Version
+Try Install Again: Try Install Again
+Update Available: Update Available
+Update Error: Update Error
+Update Install Error: Update Install Error
+'Update: Permission Denied': 'Update: Permission Denied
+Upgrade removes Pro features: Upgrade removes Pro features
+Version {{newVersion}} is available: Version {{newVersion}} is available
+View Changes: View Changes

--- a/services/translations/translations.yaml
+++ b/services/translations/translations.yaml
@@ -129,3 +129,14 @@ id:
   open_pastebar: Buka PasteBar
   unlock_pastebar: Buka kunci PasteBar
   quit: Keluar
+
+nl-NL:
+  add_first_item_here: Voeg hier het eerste item toe
+  disable_history_capture: Geschiedenisvastlegging uitschakelen
+  enable_history_capture: Geschiedenisvastlegging inschakelen
+  clipboard_image_size: Grootte van klembordafbeelding
+  history_capture_is_disabled: Vastleggen van klembordgeschiedenis is uitgeschakeld
+  recent_history: Recente geschiedenis
+  open_pastebar: PasteBar openen
+  unlock_pastebar: PasteBar ontgrendelen
+  quit: Afsluiten


### PR DESCRIPTION
Add Dutch localization files for the app by introducing multiple nl-NL/*.yaml translation files (backuprestore, calendar, collections, common, common2, contextMenus, dashboard, help, history, menus, navbar, pinned, settings, settings2, specailCopyPaste, specialCopyPaste, templates, tours, updaterl, etc.). Also update services/translations/translations.yaml to register the new nl-NL locale. This brings initial Dutch translations for UI strings across core features.